### PR TITLE
Make #lang rosette and #lang rosette/safe work

### DIFF
--- a/doc/guide/scribble/datatypes/test.rkt
+++ b/doc/guide/scribble/datatypes/test.rkt
@@ -1,4 +1,4 @@
-#lang s-exp rosette/safe
+#lang rosette/safe
 
 
 

--- a/doc/guide/scribble/essentials/poly.rkt
+++ b/doc/guide/scribble/essentials/poly.rkt
@@ -1,4 +1,4 @@
-#lang s-exp rosette/safe
+#lang rosette/safe
 
 ;(configure [bitwidth 8])
 

--- a/doc/guide/scribble/essentials/queries.rkt
+++ b/doc/guide/scribble/essentials/queries.rkt
@@ -1,4 +1,4 @@
-#lang s-exp rosette/safe
+#lang rosette/safe
 
 (define (poly x)
   (+ (* x x x x) (* 6 x x x) (* 11 x x) (* 6 x)))

--- a/doc/guide/scribble/libs/rosette-lib-test.rkt
+++ b/doc/guide/scribble/libs/rosette-lib-test.rkt
@@ -1,4 +1,4 @@
-#lang s-exp rosette
+#lang rosette
 
 (require rosette/lib/meta/meta)
 

--- a/doc/guide/scribble/reflection/test.rkt
+++ b/doc/guide/scribble/reflection/test.rkt
@@ -1,4 +1,4 @@
-#lang s-exp rosette
+#lang rosette
 
 (define-symbolic b boolean?)
 (define v (vector 1))

--- a/doc/guide/scribble/welcome/welcome.scrbl
+++ b/doc/guide/scribble/welcome/welcome.scrbl
@@ -66,11 +66,11 @@ The Rosette system ships with two dialects of the Rosette language:
 
 To use the safe dialect, start your programs with the following line:
 
-@racketmod[s-exp rosette/safe]
+@racketmod[rosette/safe]
 
 To use the unsafe dialect, type this line instead:
 
-@racketmod[s-exp rosette]
+@racketmod[rosette]
 
 We strongly recommend that you start with the safe dialect, which includes a core subset of Racket.  The unsafe dialect includes all of Racket, but unless you understand and observe the restrictions on using non-core features, your seemingly correct programs may crash or produce unexpected results.
 

--- a/rosette/lang/reader.rkt
+++ b/rosette/lang/reader.rkt
@@ -1,0 +1,2 @@
+#lang s-exp syntax/module-reader
+rosette

--- a/rosette/safe/lang/reader.rkt
+++ b/rosette/safe/lang/reader.rkt
@@ -1,0 +1,2 @@
+#lang s-exp syntax/module-reader
+rosette/safe


### PR DESCRIPTION
Adding a simple reader for `rosette` and `rosette/safe` makes `#lang rosette` and `#lang rosette/safe` work directly (as indicated in the Rosette Guide) instead of having to use `#lang s-exp rosette`.