### PR TITLE
Correct name of 'for/all*' to 'for*/all'

### DIFF
--- a/rosette/doc/guide/scribble/reflection/value-reflection.scrbl
+++ b/rosette/doc/guide/scribble/reflection/value-reflection.scrbl
@@ -237,7 +237,7 @@ Experimenting is the best way to determine whether and where to insert
 performance-guiding @racket[for/all]s.
 }]}
 
-@defform[(for/all* ([id val-expr] ...+) body)]{
+@defform[(for*/all ([id val-expr] ...+) body)]{
 Expands to a nested use of @racket[for/all], 
 just like @racket[let*] expands to a nested use of @racket[let].}                                             
                                     


### PR DESCRIPTION
The Rosette documentation incorrectly refers to the `for*/all` macro as `for/all*`. See [the actual definition](https://github.com/emina/rosette/blob/master/rosette/base/core/forall.rkt#L20).