### PR TITLE
Fix Z3 binary permissions on Windows.

### DIFF
--- a/rosette/private/install.rkt
+++ b/rosette/private/install.rkt
@@ -26,7 +26,9 @@
                          (λ (dir)
                            (copy-directory/files (build-path dir "z3") z3-path)))
         ;; Unzipping loses file permissions, so we reset the z3 binary here
-        (file-or-directory-permissions z3-path #o755)))))
+        (file-or-directory-permissions 
+          z3-path 
+          (if (equal? (system-type) 'windows) #o777 #o755))))))
 
 
 ;; Currently unused, but will be useful if Rosette is using a stable z3 release


### PR DESCRIPTION
On Windows, permissions for user/group/others must all be the same ([docs](https://docs.racket-lang.org/reference/Filesystem.html?q=file-or-directory-permissions#%28def._%28%28quote._~23~25kernel%29._file-or-directory-permissions%29%29)), so trying to set 0755 on the Z3 binary throws an exception and currently causes Windows installation to fail. Instead, we should set 0777 on Windows. But this is too permissive on Mac/Linux, where binaries should be 0755 by default. So this commit special cases the permissions for Windows only.