### PR TITLE
Add generate-symbolic method

### DIFF
--- a/rosette/base/base.rkt
+++ b/rosette/base/base.rkt
@@ -85,7 +85,7 @@
      ; form/state.rkt
      current-oracle oracle oracle? 
      ; form/define.rkt
-     define-symbolic define-symbolic*
+     define-symbolic define-symbolic* generate-symbolic
      ; form/control.rkt
      @if @and @or @not @nand @nor @xor @implies
      @unless @when @cond @case else

--- a/rosette/base/form/define.rkt
+++ b/rosette/base/form/define.rkt
@@ -3,7 +3,7 @@
 (require (for-syntax racket)
          "../util/array.rkt" "../core/term.rkt" "state.rkt")
 
-(provide define-symbolic define-symbolic*)
+(provide define-symbolic define-symbolic* generate-symbolic)
 
 #|--------------define forms--------------|#
 
@@ -36,6 +36,18 @@
      (and (identifier? #'v0) (andmap identifier? (syntax->list #'(v ...))))
      (syntax/loc stx (begin (define-symbolic* v0 type) (define-symbolic* v type) ...))]
     ))
+
+(define-syntax (generate-symbolic stx)
+  (syntax-case stx ()
+    [(_ type)
+     (syntax/loc stx
+       (with-syntax ([(var) (generate-temporaries #'(gen))])
+         (constant (list #'var ((current-oracle) #'var)) type)))]
+    [(_ type [ k ... ])
+     (syntax/loc stx
+       (with-syntax ([(var) (generate-temporaries #'(gen))])
+         (reshape (list k ...) (for/list ([i (in-range (* k ...))])
+                                 (generate-symbolic type)))))]))
 
 #|--------------helper functions--------------|#
 

--- a/rosette/doc/guide/scribble/forms/rosette-forms.scrbl
+++ b/rosette/doc/guide/scribble/forms/rosette-forms.scrbl
@@ -61,6 +61,16 @@ The @seclink["ch:essentials"]{Essentials} chapter introduced the key concepts of
   (always-different) 
   (eq? (always-different) (always-different))]
 }
+@defform[(generate-symbolic type)
+         #:contracts
+         [(type (and/c solvable? type?))]]{
+  Returns a single @tech["symbolic constant"] of the given
+  @tech["solvable type"]. This constant is not bound to a variable, and
+  seperate invocations generate seperate constants.
+
+  This avoids needing to use @racket[define-symbolic*] inside a function
+  to generate new symbolic variables.
+}
 
 @section[#:tag "sec:assertions"]{Assertions}
 


### PR DESCRIPTION
Every Rosette project (that i have come across so far) has a function defined like the following, which suggests this is something that could usefully be extracted into the rosette library functions themselves.

```racket
(define (make-thing)
  (define-symbolic* thing boolean?)
  thing)
```

With `generate-symbolic`, this can be changed to the following, or calls to `make-thing` can be replaced with calls to `generate-symbolic`.

```racket
(define (make-thing)
  (generate-symbolic boolean?))
```

While this behaviour can be achieved using `constant`, the interface to `constant` is not particularly easy to understand, and is undocumented. Having `generate-symbolic` with an interface like `define-symbolic` would allow you, the rosette authors, to change the details of the `constant` interface without necessarily breaking library code.

To Do: I wanted to add an example to the docs, but when I did, something lower down the file broke in a `clear-asserts!`, and I couldn't work out why.