### PR TITLE
fix bitvector printing

### DIFF
--- a/rosette/base/core/bitvector.rkt
+++ b/rosette/base/core/bitvector.rkt
@@ -64,7 +64,7 @@
    (define (solvable-range self) self)]
   #:methods gen:custom-write
   [(define (write-proc self port m) 
-     (fprintf port "(bitvector? ~a)" (bitvector-size self)))])
+     (fprintf port "(bitvector ~a)" (bitvector-size self)))])
 
 ; Pattern matching for bitvector types.
 (define-match-expander @bitvector


### PR DESCRIPTION
An improperly sized bitvector argument error prints strangely: 

```
(bveq (bv 1 (bitvector 2)) (bv 1 (bitvector 3)))
; => bveq: expected (bitvector? 2), given (bv 1 3)
```

I expected the error message to report a predicate, ie `(bitvector 2)`