### PR TITLE
use no-vert-bar-lang pkg to properly define ||

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - rm z3.zip
 
 install: 
-  - raco pkg install
+  - raco pkg install --deps search-auto
 
 script:
   - raco test 

--- a/info.rkt
+++ b/info.rkt
@@ -2,13 +2,14 @@
 
 (define collection 'multi)
 
-(define deps '("r6rs-lib"
+(define deps '("no-vert-bar-lang"
+               "r6rs-lib"
                "rackunit-lib"
                "slideshow-lib"
                "base"))
 (define build-deps '("pict-doc"
                      "scribble-lib"
-                    "racket-doc"))
+                     "racket-doc"))
 
 (define pkg-desc "Rosette solver-aided host language")
 (define version "2")

--- a/rosette/base/adt/box.rkt
+++ b/rosette/base/adt/box.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax "../core/lift.rkt") racket/provide 
          "../core/safe.rkt" "generic.rkt"

--- a/rosette/base/adt/generic.rkt
+++ b/rosette/base/adt/generic.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (only-in "../core/union.rkt" union union-filter union-guards union-contents)
          (only-in "../core/type.rkt" subtype?)

--- a/rosette/base/adt/list.rkt
+++ b/rosette/base/adt/list.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax "../core/lift.rkt") 
          racket/provide racket/splicing racket/stxparam 

--- a/rosette/base/adt/seq.rkt
+++ b/rosette/base/adt/seq.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax "../core/lift.rkt") 
          racket/splicing racket/stxparam

--- a/rosette/base/adt/vector.rkt
+++ b/rosette/base/adt/vector.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax "../core/lift.rkt") 
          racket/provide 

--- a/rosette/base/base.rkt
+++ b/rosette/base/base.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 ;; ------ Rosette (lifted) syntax and  procedures ------ ;; 
 (require 
@@ -12,12 +12,11 @@
   "form/state.rkt" "form/define.rkt" "form/control.rkt" "form/module.rkt" "form/app.rkt") 
 
 (provide
-  (rename-out [@|| ||]) ; The character sequence || does not play nicely with the filtered-out form.
   (filtered-out drop@ 
     (combine-out   
      ; core/bool.rkt
      pc with-asserts with-asserts-only asserts clear-asserts!
-     @assert @boolean? @false? @! @&& @=> @<=> 
+     @assert @boolean? @false? @! @&& @=> @<=> @||
      ; core/real.rkt
      @integer? @real? @= @< @<= @>= @> 
      @+ @* @- @/ @quotient @remainder @modulo @abs

--- a/rosette/base/core/bitvector.rkt
+++ b/rosette/base/core/bitvector.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax) racket/stxparam racket/stxparam-exptime)
 (require "term.rkt" "union.rkt" "bool.rkt" "polymorphic.rkt" 

--- a/rosette/base/core/bool.rkt
+++ b/rosette/base/core/bool.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require "term.rkt" "union.rkt")
 

--- a/rosette/base/core/equality.rkt
+++ b/rosette/base/core/equality.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require "term.rkt" "union.rkt" "bool.rkt")
 

--- a/rosette/base/core/forall.rkt
+++ b/rosette/base/core/forall.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require racket/splicing (for-syntax racket/syntax) 
          (only-in racket/unsafe/ops [unsafe-car car] [unsafe-cdr cdr])

--- a/rosette/base/core/function.rkt
+++ b/rosette/base/core/function.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require racket/generic
          "term.rkt" "bool.rkt" "safe.rkt" "union.rkt"  "equality.rkt"  "merge.rkt"

--- a/rosette/base/core/merge.rkt
+++ b/rosette/base/core/merge.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (only-in rnrs/base-6 assert)
          (only-in racket/unsafe/ops [unsafe-car car] [unsafe-cdr cdr])

--- a/rosette/base/core/polymorphic.rkt
+++ b/rosette/base/core/polymorphic.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require "term.rkt" "union.rkt" "bool.rkt")
 

--- a/rosette/base/core/procedure.rkt
+++ b/rosette/base/core/procedure.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require 
   racket/provide 

--- a/rosette/base/core/real.rkt
+++ b/rosette/base/core/real.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (for-syntax racket/syntax) racket/stxparam racket/stxparam-exptime)
 (require "term.rkt" "union.rkt" "bool.rkt" "polymorphic.rkt" 

--- a/rosette/base/core/safe.rkt
+++ b/rosette/base/core/safe.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require (only-in "type.rkt" type-cast)
          "bool.rkt"

--- a/rosette/base/struct/struct-type.rkt
+++ b/rosette/base/struct/struct-type.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 
 (require (for-syntax "../core/lift.rkt" racket/syntax)

--- a/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
+++ b/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
@@ -1,4 +1,4 @@
-#lang scribble/manual
+#lang no-vert-bar scribble/manual
 
 @(require (for-label 
            rosette/base/form/define rosette/solver/solution rosette/query/query rosette/query/eval 
@@ -89,7 +89,7 @@ The hole @racket[(id e ... k)] must specify the inlining bound
  (code:comment "The body of nnf=> is a hole to be filled with an")
  (code:comment "expression of depth (up to) 1 from the NNF grammar.")
  (define (nnf=> a b)
-   (nnf x y 1)))
+   (nnf a b 1)))
 (define-symbolic a b boolean?)
 (eval:alts
  (print-forms

--- a/rosette/lang/reader.rkt
+++ b/rosette/lang/reader.rkt
@@ -1,2 +1,7 @@
 #lang s-exp syntax/module-reader
 rosette
+#:wrapper1 (lambda (th) 
+             (parameterize 
+                 ([current-readtable (make-no-vert-bar-readtable)])
+               (th)))
+(require no-vert-bar/reader)

--- a/rosette/query/core.rkt
+++ b/rosette/query/core.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require 
   racket/generator

--- a/rosette/query/form.rkt
+++ b/rosette/query/form.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require "core.rkt" 
          (only-in "../base/core/reflect.rkt" symbolics)

--- a/rosette/solver/smt/enc.rkt
+++ b/rosette/solver/smt/enc.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require "env.rkt" 
          (prefix-in $ "smtlib2.rkt") 

--- a/sdsl/bv/lang/core.rkt
+++ b/sdsl/bv/lang/core.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require 
   (only-in "bvops.rkt" BV bv* bv)

--- a/sdsl/synthcl/test/snippets.rkt
+++ b/sdsl/synthcl/test/snippets.rkt
@@ -1,4 +1,4 @@
-#lang s-exp "../lang/main.rkt"
+#lang no-vert-bar s-exp "../lang/main.rkt"
 
 (: int x)
 (: char* y)

--- a/sdsl/synthcl/test/typecheck.rkt
+++ b/sdsl/synthcl/test/typecheck.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui rosette/lib/roseunit
          (only-in "../model/memory.rkt" NULL)

--- a/test/base/bitvector.rkt
+++ b/test/base/bitvector.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui racket/generator
          rosette/solver/solution 

--- a/test/base/bool.rkt
+++ b/test/base/bool.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui rosette/lib/roseunit
          rosette/base/core/term

--- a/test/base/equality.rkt
+++ b/test/base/equality.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui rosette/lib/roseunit
          rosette/base/core/equality 

--- a/test/base/merge.rkt
+++ b/test/base/merge.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui rosette/lib/roseunit
          rosette/base/core/term

--- a/test/base/real.rkt
+++ b/test/base/real.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui  "common.rkt" "solver.rkt"
          rosette/solver/solution 

--- a/test/base/term.rkt
+++ b/test/base/term.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang no-vert-bar racket
 
 (require rackunit rackunit/text-ui rosette/lib/roseunit
          rosette/base/core/term


### PR DESCRIPTION
By default, the vertical bar (`|`) has special meaning to the Racket reader. It "quotes" identifiers such that writing `||` does not produce the identifier `||` but rather a 0-length identifier.

This pull request uses the `no-vert-bar-lang` pkg to disable this feature and allow vertical bars in identifiers, so that `||` is properly defined. In particular, this allows removing the `rename-out` workaround in rosette/base/base.rkt.

One side effect is that `||` now renders as `\|\|` in the documention (of `define-synthax`). This should not cause any problems though, since it is still valid syntax if someone tries to copy-paste and run the example.

EDIT: `||` will also render as `\|\|` when printed.