### PR TITLE
Added support for variadic methods in define-generics

### DIFF
--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -11,14 +11,24 @@
 
 (define-syntax (@define-generics stx)
   (syntax-case stx ()
-    [(_ id [method self arg ...] ...)
+    [(_ id method ...)
      (with-syntax ([id? (format-id #'id "~a?" #'id #:source #'id)])
        (syntax/loc stx 
          (begin
            (define-generics id
-            [method self arg ...] ...)
+            method ...)
            (set! id? (lift id? receiver))
-           (set! method (lift method receiver arg ...)) ...)))]))
+           (handle-method method) ...)))]))
+
+(define-syntax (handle-method stx)
+  (syntax-case stx ()
+    [(_ (method self arg ...))
+     (syntax/loc stx
+       (set! method (lift method receiver arg ...)))]
+    [(_ (method self arg ... . rest))
+     (syntax/loc stx
+       (set! method (lift-variadic method receiver arg ... . rest)))]))
+    
 
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
@@ -34,9 +44,19 @@
           (proc receiver arg ...)))
      (or (object-name proc) 'proc))))
 
+(define-syntax-rule (lift-variadic proc receiver arg ... . rest)
+  (let ([proc proc])
+    (procedure-rename
+     (lambda (receiver arg ... . rest)
+      (if (union? receiver)
+          (for/all ([r receiver]) (apply proc r arg ... rest))
+          (apply proc receiver arg ... rest)))
+     (or (object-name proc) 'proc))))
+
+
 #|
 ; sanity check
-(define-generics foo [some foo])
+(@define-generics foo [some foo])
 some
 
 (struct bar (arg)
@@ -45,13 +65,36 @@ some
 
 (some (bar 'yes))
 
-(require (only-in rosette/base/define define-symbolic)
-         (only-in rosette/base/bool @boolean?))
+(require (only-in rosette/base/form/define define-symbolic)
+         (only-in rosette/base/core/bool @boolean?)
+         (only-in rosette/base/core/real @* @+))
 
 (define-symbolic b @boolean?)
-
 (some (@if b (bar 'yes) (bar 'no)))
-(foo? (@if b (bar 'yes) (bar 'no)))|#
+(foo? (@if b (bar 'yes) (bar 'no)))
 
+(@define-generics xyzzy
+  (h xyzzy))
 
-    
+(@define-generics variadic
+  (f variadic . x)
+  (g variadic))
+
+(struct multiplier (y) #:transparent
+  #:methods gen:variadic
+  [(define (f self . x) (foldl @* (multiplier-y self) x))
+   (define (g self) 'g-mult)]
+  #:methods gen:xyzzy
+  [(define (h self) 42)])
+
+(struct adder (z) #:transparent
+  #:methods gen:variadic
+  [(define (f self . x) (foldl @+ (adder-z self) x))
+   (define (g self) 'g-add)])
+
+(define thing (@if b (multiplier 3) (adder 3)))
+(variadic? thing)
+thing
+(f thing 2 5)
+(g thing)
+(h thing)|#


### PR DESCRIPTION
Also improved the sanity check. The sanity check does not work properly if you run "racket generics.rkt" (for some reason @false? does not recognize the boolean variable created by define-symbolic), but it does run if you copy paste it as a Rosette program, after removing the requires and the @ characters.