### PR TITLE
use make-variable-like-transformer where appropriate

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,11 +5,11 @@
 (define deps '("r6rs-lib"
                "rackunit-lib"
                "slideshow-lib"
-               "base"))
+               ["base" #:version "6.3"]))
 
 (define build-deps '("pict-doc"
                      "scribble-lib"
-                    "racket-doc"))
+                     "racket-doc"))
 
 (define test-omit-paths (if (getenv "PLT_PKG_BUILD_SERVICE") 'all '()))
 

--- a/rosette/base/core/bitvector.rkt
+++ b/rosette/base/core/bitvector.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require (for-syntax racket/syntax) racket/stxparam racket/stxparam-exptime)
+(require racket/stxparam racket/stxparam-exptime
+         (for-syntax racket/syntax syntax/transformer))
 (require "term.rkt" "union.rkt" "bool.rkt" "polymorphic.rkt" 
          "merge.rkt" "safe.rkt" "lift.rkt" "forall.rkt")
 (require (only-in "real.rkt" @>= @> @= @integer? T*->integer?))
@@ -70,9 +71,7 @@
 (define-match-expander @bitvector
   (syntax-rules ()
     [(_ sz) (bitvector sz)])
-  (syntax-id-rules (set!)
-    [(@bitvector sz) (bitvector-type sz)]
-    [@bitvector bitvector-type]))
+  (make-variable-like-transformer #'bitvector-type))
 
 (define (bvsmin t) (- (expt 2 (- (bitvector-size t) 1))))
 (define (bvsmin? b) (and (bv? b) (= (bv-value b) (bvsmin (bv-type b)))))
@@ -127,9 +126,7 @@
 (define-match-expander @bv
   (syntax-rules ()
     [(_ val-pat type-pat) (bv val-pat type-pat)])
-  (syntax-id-rules (set!)
-    [(@bv v t) (make-bv v t)]
-    [@bv make-bv]))
+  (make-variable-like-transformer #'make-bv))
 
 (define (@bv? v)
   (match v

--- a/rosette/base/core/function.rkt
+++ b/rosette/base/core/function.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require racket/generic
+         (for-syntax syntax/transformer)
          "term.rkt" "bool.rkt" "safe.rkt" "union.rkt"  "equality.rkt"  "merge.rkt"
          (only-in "procedure.rkt" @procedure?))
 
@@ -105,9 +106,7 @@
   (lambda (stx)
     (syntax-case stx ()
       [(_ pat ...) #'(fv pat ... _)]))
-  (syntax-id-rules ()
-    [(_ ios o type) (make-fv ios o type)]
-    [_ make-fv])) 
+  (make-variable-like-transformer #'make-fv)) 
 
 (define (@fv? v)
   (match v

--- a/rosette/base/core/polymorphic.rkt
+++ b/rosette/base/core/polymorphic.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require "term.rkt" "union.rkt" "bool.rkt")
+(require "term.rkt" "union.rkt" "bool.rkt"
+         (for-syntax syntax/transformer))
 
 (provide 
  ite ite* ⊢ guarded guarded-test guarded-value =?    
@@ -67,9 +68,7 @@
   (lambda (stx)
     (syntax-case stx ()
       [(_ g-pat v-pat) #'(expression (== ⊢) g-pat v-pat)]))
-  (syntax-id-rules ()
-    [(_ g v) (make-guarded g v)]
-    [_ make-guarded]))
+  (make-variable-like-transformer #'make-guarded))
 
 (define (guarded-test gv) 
   (match gv [(expression (== ⊢) g _) g]))

--- a/rosette/base/core/term.rkt
+++ b/rosette/base/core/term.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require racket/syntax (for-syntax racket racket/syntax) racket/generic "type.rkt")
+(require racket/syntax racket/generic "type.rkt"
+         (for-syntax racket/base racket/syntax syntax/transformer))
 
 (provide
  term-cache clear-terms!
@@ -93,17 +94,13 @@
   (lambda (stx)
     (syntax-case stx ()
       [(_ id-pat type-pat) #'(constant id-pat type-pat _)]))
-  (syntax-id-rules ()
-    [(_ id type) (make-const id type)]
-    [_ make-const]))
+  (make-variable-like-transformer #'make-const))
 
 (define-match-expander an-expression
   (lambda (stx)
     (syntax-case stx ()
       [(_ op-pat elts-pat ...) #'(expression (list op-pat elts-pat ...) _ _)]))
-  (syntax-id-rules ()
-    [(_ op elts ...) (make-expr op elts ...)]
-    [_ make-expr]))
+  (make-variable-like-transformer #'make-expr))
 
 (define-match-expander a-term
   (syntax-rules ()

--- a/rosette/base/core/union.rkt
+++ b/rosette/base/core/union.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require "term.rkt")
+(require "term.rkt"
+         (for-syntax syntax/transformer))
 
 (provide union? (rename-out [a-union union])
          union-contents union-type union-guards union-values union-filter
@@ -108,6 +109,4 @@
      (union (list-no-order (cons guard-pat val-pat) ...) _)]
     [(_ : (guard-pat val-pat) ...+ lvp ...) 
      (union (list-no-order (cons guard-pat val-pat) ...+ lvp ...) _)])
-  (syntax-id-rules (set!)
-    [(a-union v ...) (make-union v ...)]
-    [a-union make-union]))
+  (make-variable-like-transformer #'make-union))

--- a/rosette/base/util/array.rkt
+++ b/rosette/base/util/array.rkt
@@ -25,11 +25,10 @@
     [(_ id vals) 
      #`(splicing-let ([array (array-procedure vals)])
          (define-syntax id
-           (syntax-id-rules (set!)
-             [(set! id e) 
-              (error 'set! "cannot modify an immutable reference: ~s" (syntax->datum #'id))]
-             [(id idx (... ...)) (array idx (... ...))]
-             [id (array)])))]))
+           (lambda (stx)
+             (syntax-case stx ()
+               [(id idx (... ...)) #'(array idx (... ...))]
+               [the-id (identifier? #'the-id) #'(array)]))))]))
 
 ; This macro expands to a procedure wrapper that allows
 ; the elements in the given nested list representation of 

--- a/rosette/solver/solution.rkt
+++ b/rosette/solver/solution.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require "../base/core/term.rkt")
+(require "../base/core/term.rkt"
+         (for-syntax syntax/transformer))
 
 (provide solution? sat? unsat? unknown?
          (rename-out [make-sat sat] [make-unsat unsat] [make-unknown unknown])
@@ -57,17 +58,13 @@
   (syntax-rules ()
     [(model) (sat (app dict-count 0))]
     [(model pat) (sat pat)])
-  (syntax-id-rules (set!)
-    [(model s) (sat-model s)]
-    [model sat-model]))
+  (make-variable-like-transformer #'sat-model))
 
 (define-match-expander core
   (syntax-rules ()
     [(core) (unsat #f)]
     [(core pat) (unsat pat)])
-  (syntax-id-rules (set!)
-    [(core s) (unsat-core s)]
-    [core unsat-core]))
+  (make-variable-like-transformer #'unsat-core))
 
 (define sat0 (sat (hash)))
 (define unsat0 (unsat #f))

--- a/sdsl/ifc/instruction.rkt
+++ b/sdsl/ifc/instruction.rkt
@@ -1,6 +1,7 @@
 #lang rosette
 
-(require rosette/lib/match rosette/lib/angelic "value.rkt")
+(require rosette/lib/match rosette/lib/angelic "value.rkt"
+         (for-syntax syntax/transformer))
 
 (provide program instruction
          (rename-out [inst? instruction?]
@@ -49,9 +50,7 @@
 (define-match-expander instruction
   (syntax-rules () 
     [(_ proc args) (inst proc args)])
-  (syntax-id-rules ()
-    [(instruction proc arg ...) (make-inst proc arg ...)]
-    [instruction                make-inst]))
+  (make-variable-like-transformer #'make-inst))
 
 ; Returns thunk that prodcues a list of fresh symbolic instructions. If given a list of k 
 ; procedures, the thunk's output list contains k instructions such that the ith 

--- a/sdsl/ifc/value.rkt
+++ b/sdsl/ifc/value.rkt
@@ -74,7 +74,8 @@
 ; the number of return values.
 (define-match-expander R
   (syntax-rules () [(_ pc-pat n-pat) (return pc-pat n-pat)])
-  (syntax-id-rules ()
-    [(R pc)   (return pc 0@⊥)]
-    [(R pc n) (return pc n)]
-    [R        return]))
+  (lambda (stx)
+    (syntax-case stx ()
+      [(R pc)   #'(return pc 0@⊥)]
+      [(R pc n) #'(return pc n)]
+      [R (identifier? #'R) #'return])))


### PR DESCRIPTION
This fixes #26 by changing `bitvector` to use `(make-variable-like-transformer #'bitvector-type)` instead of `(syntax-id-rules ....)`. It also changes many other uses of `syntax-id-rules` that had similar problems. 