### PR TITLE
Added support and tests for the various options in define-generics

### DIFF
--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -11,14 +11,24 @@
 
 (define-syntax (@define-generics stx)
   (syntax-case stx ()
-    [(_ id [method self arg ...] ...)
+    [(_ id method ...)
      (with-syntax ([id? (format-id #'id "~a?" #'id #:source #'id)])
        (syntax/loc stx 
          (begin
            (define-generics id
-            [method self arg ...] ...)
+            method ...)
            (set! id? (lift id? receiver))
-           (set! method (lift method receiver arg ...)) ...)))]))
+           (handle-method method) ...)))]))
+
+(define-syntax (handle-method stx)
+  (syntax-case stx ()
+    [(_ (method self arg ...))
+     (syntax/loc stx
+       (set! method (lift method receiver arg ...)))]
+    [(_ (method self arg ... . rest))
+     (syntax/loc stx
+       (set! method (lift-variadic method receiver arg ... . rest)))]))
+    
 
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
@@ -34,9 +44,19 @@
           (proc receiver arg ...)))
      (or (object-name proc) 'proc))))
 
+(define-syntax-rule (lift-variadic proc receiver arg ... . rest)
+  (let ([proc proc])
+    (procedure-rename
+     (lambda (receiver arg ... . rest)
+      (if (union? receiver)
+          (for/all ([r receiver]) (apply proc r arg ... rest))
+          (apply proc receiver arg ... rest)))
+     (or (object-name proc) 'proc))))
+
+
 #|
 ; sanity check
-(define-generics foo [some foo])
+(@define-generics foo [some foo])
 some
 
 (struct bar (arg)
@@ -45,13 +65,36 @@ some
 
 (some (bar 'yes))
 
-(require (only-in rosette/base/define define-symbolic)
-         (only-in rosette/base/bool @boolean?))
+(require (only-in rosette/base/form/define define-symbolic)
+         (only-in rosette/base/core/bool @boolean?)
+         (only-in rosette/base/core/real @* @+))
 
 (define-symbolic b @boolean?)
-
 (some (@if b (bar 'yes) (bar 'no)))
-(foo? (@if b (bar 'yes) (bar 'no)))|#
+(foo? (@if b (bar 'yes) (bar 'no)))
 
+(@define-generics xyzzy
+  (h xyzzy))
 
-    
+(@define-generics variadic
+  (f variadic . x)
+  (g variadic))
+
+(struct multiplier (y) #:transparent
+  #:methods gen:variadic
+  [(define (f self . x) (foldl @* (multiplier-y self) x))
+   (define (g self) 'g-mult)]
+  #:methods gen:xyzzy
+  [(define (h self) 42)])
+
+(struct adder (z) #:transparent
+  #:methods gen:variadic
+  [(define (f self . x) (foldl @+ (adder-z self) x))
+   (define (g self) 'g-add)])
+
+(define thing (@if b (multiplier 3) (adder 3)))
+(variadic? thing)
+thing
+(f thing 2 5)
+(g thing)
+(h thing)|#

--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -1,6 +1,9 @@
 #lang racket
 
-(require (for-syntax (only-in racket/syntax format-id))
+(require (for-syntax (only-in racket/syntax
+                              format-id wrong-syntax generate-temporary
+                              current-syntax-context)
+                     (only-in syntax/stx stx-car))
          (only-in racket/generic define-generics)
          (only-in "../form/control.rkt" @if)
          (only-in "../core/bool.rkt" @assert)
@@ -9,50 +12,145 @@
 
 (provide @define-generics @make-struct-type-property)
 
+(begin-for-syntax
+
+  ;; parse is copied without modifications from racket/generic
+  (define (parse stx [options (hasheq)])
+    (syntax-case stx ()
+      [(#:defined-predicate name . args)
+       (identifier? #'name)
+       (if (hash-ref options 'support #f)
+           (wrong-syntax (stx-car stx)
+                         "duplicate #:defined-predicate specification")
+           (parse #'args (hash-set options 'support #'name)))]
+      [(#:defined-predicate . other)
+       (wrong-syntax (stx-car stx) "invalid #:defined-predicate specification")]
+      [(#:defined-table name . args)
+       (identifier? #'name)
+       (if (hash-ref options 'table #f)
+           (wrong-syntax (stx-car stx)
+                         "duplicate #:defined-table specification")
+           (parse #'args (hash-set options 'table #'name)))]
+      [(#:defined-table . other)
+       (wrong-syntax (stx-car stx) "invalid #:defined-table specification")]
+      [(#:defaults (clause ...) . args)
+       (if (hash-ref options 'defaults #f)
+           (wrong-syntax (stx-car stx) "duplicate #:defaults specification")
+           (let loop ([defaults '()]
+                      [clauses (reverse (syntax->list #'(clause ...)))])
+             (if (pair? clauses)
+                 (syntax-case (car clauses) ()
+                   [(pred #:dispatch disp defn ...)
+                    (loop (cons #'[pred disp defn ...] defaults)
+                          (cdr clauses))]
+                   [(pred defn ...)
+                    (with-syntax ([name (generate-temporary #'pred)])
+                      (loop (cons #'[pred #:same defn ...] defaults)
+                            (cdr clauses)))]
+                   [clause
+                    (wrong-syntax #'clause "invalid #:defaults specification")])
+                 (parse #'args
+                        (hash-set* options 'defaults defaults)))))]
+      [(#:defaults . other)
+       (wrong-syntax (stx-car stx) "invalid #:defaults specification")]
+      [(#:fast-defaults (clause ...) . args)
+       (if (hash-ref options 'fast-defaults #f)
+           (wrong-syntax (stx-car stx)
+                         "duplicate #:fast-defaults specification")
+           (let loop ([fast-defaults '()]
+                      [clauses (reverse (syntax->list #'(clause ...)))])
+             (if (pair? clauses)
+                 (syntax-case (car clauses) ()
+                   [(pred #:dispatch disp defn ...)
+                    (loop (cons #'[pred disp defn ...] fast-defaults)
+                          (cdr clauses))]
+                   [(pred defn ...)
+                    (with-syntax ([name (generate-temporary #'pred)])
+                      (loop (cons #'[pred #:same defn ...] fast-defaults)
+                            (cdr clauses)))]
+                   [clause
+                    (wrong-syntax #'clause
+                                  "invalid #:fast-defaults specification")])
+                 (parse #'args
+                        (hash-set* options
+                                   'fast-defaults fast-defaults)))))]
+      [(#:fast-defaults . other)
+       (wrong-syntax (stx-car stx) "invalid #:fast-defaults specification")]
+      [(#:fallbacks [fallback ...] . args)
+       (if (hash-ref options 'fallbacks #f)
+           (wrong-syntax (stx-car stx) "duplicate #:fallbacks specification")
+           (parse #'args (hash-set options 'fallbacks #'[fallback ...])))]
+      [(#:fallbacks . other)
+       (wrong-syntax (stx-car stx) "invalid #:fallbacks specification")]
+      [(#:derive-property prop impl . args)
+       (parse #'args
+              (hash-set options
+                        'derived
+                        (cons (list #'prop #'impl)
+                              (hash-ref options 'derived '()))))]
+      [(#:derive-property . other)
+       (wrong-syntax (stx-car stx) "invalid #:derive-property specification")]
+      [(kw . args)
+       (keyword? (syntax-e #'kw))
+       (wrong-syntax #'kw "invalid keyword argument")]
+      [((_ . _) . args)
+       (if (hash-ref options 'methods #f)
+           (wrong-syntax (stx-car stx) "duplicate methods list specification")
+           (let loop ([methods (list (stx-car stx))] [stx #'args])
+             (syntax-case stx ()
+               [((_ . _) . args) (loop (cons (stx-car stx) methods) #'args)]
+               [_ (parse stx (hash-set options 'methods (reverse methods)))])))]
+      [(other . args)
+       (wrong-syntax #'other
+                     "expected a method identifier with formal arguments")]
+      [() (values (hash-ref options 'methods '())
+                  (hash-ref options 'support generate-temporary)
+                  (hash-ref options 'table #f)
+                  (hash-ref options 'fast-defaults '())
+                  (hash-ref options 'defaults '())
+                  (hash-ref options 'fallbacks '())
+                  (hash-ref options 'derived '()))]
+      [other
+       (wrong-syntax #'other
+                     "expected a list of arguments with no dotted tail")])))
+
 (define-syntax (@define-generics stx)
   (syntax-case stx ()
-    [(_ id method ...)
-     (with-syntax ([id? (format-id #'id "~a?" #'id #:source #'id)])
-       (syntax/loc stx 
-         (begin
-           (define-generics id
-            method ...)
-           (set! id? (lift id? receiver))
-           (handle-method method) ...)))]))
+    [(_ id . rest)
+     (parameterize ([current-syntax-context stx])
+       (unless (identifier? #'id)
+         (wrong-syntax #'id "expected an identifier"))
+       (define-values
+         (methods support table fasts defaults fallbacks derived)
+         (parse #'rest))
+       
+       (when table
+         (wrong-syntax table
+                       "#:defined-table option is not supported in Rosette"))
 
-(define-syntax (handle-method stx)
-  (syntax-case stx ()
-    [(_ (method self arg ...))
-     (syntax/loc stx
-       (set! method (lift method receiver arg ...)))]
-    [(_ (method self arg ... . rest))
-     (syntax/loc stx
-       (set! method (lift-variadic method receiver arg ... . rest)))]))
+       (with-syntax ([id? (format-id #'id "~a?" #'id #:source #'id)]
+                     [((method-name . dummy) ...) methods]
+                     [support-name support])
+         (syntax/loc stx 
+           (begin
+             (define-generics id . rest)
+             (set! id? (lift id? receiver))
+             (set! support-name (lift support-name receiver))
+             (set! method-name (lift method-name receiver)) ...))))]))
     
-
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
     (make-struct-type-property name guard supers can-impersonate?))
   (values prop:p (lift p? self) (lift p-ref self)))
 
-(define-syntax-rule (lift proc receiver arg ...)
+(define-syntax-rule (lift proc receiver)
   (let ([proc proc])
     (procedure-rename
-     (lambda (receiver arg ...)
+     (lambda (receiver . args)
       (if (union? receiver)
-          (for/all ([r receiver]) (proc r arg ...))
-          (proc receiver arg ...)))
+          (for/all ([r receiver]) (apply proc r args))
+          (apply proc receiver args)))
      (or (object-name proc) 'proc))))
-
-(define-syntax-rule (lift-variadic proc receiver arg ... . rest)
-  (let ([proc proc])
-    (procedure-rename
-     (lambda (receiver arg ... . rest)
-      (if (union? receiver)
-          (for/all ([r receiver]) (apply proc r arg ... rest))
-          (apply proc receiver arg ... rest)))
-     (or (object-name proc) 'proc))))
-
 
 #|
 ; sanity check

--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -141,7 +141,7 @@
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
     (make-struct-type-property name guard supers can-impersonate?))
-  (values prop:p (lift 'p? p? self) (lift 'p-ref p-ref self)))
+  (values prop:p (lift p? self) (lift p-ref self)))
 
 (define-syntax-rule (lift proc receiver)
   (let ([proc proc])

--- a/test/all-rosette-tests.rkt
+++ b/test/all-rosette-tests.rkt
@@ -17,6 +17,7 @@
  "base/finitize.rkt"
  "base/list.rkt"
  "base/vector.rkt"
+ "base/generics.rkt"
  "query/solve.rkt"
  "query/verify.rkt"
  "query/synthesize.rkt"

--- a/test/base/generics.rkt
+++ b/test/base/generics.rkt
@@ -1,0 +1,132 @@
+#lang rosette
+
+(require rackunit rackunit/text-ui rosette/lib/roseunit)
+
+(define-generics evaluator
+  (evaluat evaluator [env])
+  (f evaluator . args)
+  #:defined-predicate has-methods?
+  #:fallbacks
+  [(define (f self . args)
+     (if (null? args)
+         0
+         (+ (car args) (apply f self (cdr args)))))]
+  #:fast-defaults
+  ([number?
+    (define (evaluat thing [env #hash()]) thing)
+    (define (f self . args) self)]
+   [symbol?
+    (define (evaluat thing [env #hash()])
+      (hash-ref env thing))])
+  #:derive-property prop:procedure evaluat
+  #:defaults
+  ([pair?
+    (define (evaluat thing [env #hash()])
+      (if (not (pair? thing))
+          thing
+          (apply (car thing) (map (lambda (x) (evaluat x env))
+                                  (cdr thing)))))]))
+
+(struct Adder (x y)
+  #:methods gen:evaluator
+  [(define/generic super-evaluat evaluat)
+   (define (evaluat self [env #hash()])
+     (+ (super-evaluat (Adder-x self) env)
+        (super-evaluat (Adder-y self) env)))])
+
+(struct Multiplier (x y)
+  #:methods gen:evaluator
+  [(define/generic super-evaluat evaluat)
+   (define (evaluat self [env #hash()])
+     (* (super-evaluat (Multiplier-x self) env)
+        (super-evaluat (Multiplier-y self) env)))])
+
+;; An example where we don't use define/generic but still have recursion
+(struct Applier (fn x y)
+  #:methods gen:evaluator
+  [(define (evaluat self [env #hash()])
+     (if (number? self)
+         self
+         ((Applier-fn self)
+          (evaluat (Applier-x self) env)
+          (evaluat (Applier-y self) env))))])
+
+(define gen-concrete-tests
+  (test-suite+
+   "Concrete tests for define-generics"
+
+   ;; Generic function evaluation
+   (check-equal? (evaluat (Adder (Multiplier 'x 3) (list + 2 3))
+                           #hash((x . 2)))
+                 11)
+
+   (define eleven (Applier + (Applier * 2 3) 5))
+
+   ;; Tests for #:defined-predicate
+   (check-false (has-methods? eleven 'evaluat 'f))
+   (check-true (has-methods? 11 'evaluat 'f))
+
+   ;; Tests for optional arguments and variadic function
+   (check-equal? (evaluat eleven) 11)
+   (check-equal? (f eleven 2 4 6 8 10) 30)
+
+   ;; Tests for #:derive-property
+   (check-equal? (eleven) 11)))
+
+(define gen-symbolic-tests
+  (test-suite+
+   "Symbolic tests for define-generics"
+   (define-symbolic b boolean?)
+
+   ;; Tests for generic function evaluation with optional arguments
+   (define eleven-or-one
+     (evaluat (Adder (Multiplier 'x (if b 3 0))
+                      (if b (list + 2 3) (list - 3 2)))
+              #hash((x . 2))))
+   (define ten-or-seven
+     (evaluat (if b
+                  (Applier * (if b (Applier + 2 (if b 3 4)) 8) 2)
+                  (Applier + 3 4))))
+
+   
+   (define sixteen-or-seven-obj
+     (if b
+         (Multiplier (if b (Adder 3 (if b 1 'x)) (Multiplier 2 2))
+                     'y)
+         (Adder 3 'y)))
+   
+   ;; Tests for #:defined-predicate and #:derive-property
+   (define has-evaluat
+     (has-methods? sixteen-or-seven-obj 'evaluat))
+   (define sixteen-or-seven
+     (sixteen-or-seven-obj #hash((x . 2) (y . 4))))
+   (define adder-or-number
+     (if b (Adder 1 2) 4))
+   (define three-or-four (evaluat adder-or-number))
+   (define has-both-methods?
+     (has-methods? adder-or-number 'evaluat 'f))
+
+   ;; Tests for #:defaults and #:fast-defaults
+   (define four-or-fifteen
+     (evaluat (if b
+                  (list * (if b 2 3) (if b 2 10))
+                  (list + (if b 1 2) (if b 2 4) 4 5))))
+
+   ;; Tests for #:fallbacks
+   (define multiplier-or-number (if b (Multiplier 10 20) 7))
+   (define fourteen-or-seven
+     (f multiplier-or-number (if b 3 4) 5 (if b 6 7)))
+
+   (define solution (solve (assert (= three-or-four 3))))
+   (check-sat solution)
+   (check-equal? (evaluate eleven-or-one solution) 11)
+   (check-equal? (evaluate ten-or-seven solution) 10)
+   (check-true (evaluate has-evaluat solution))
+   (check-equal? (evaluate sixteen-or-seven solution) 16)
+   (check-equal? (evaluate three-or-four solution) 3)
+   (check-false (evaluate has-both-methods? solution))
+   (check-equal? (evaluate four-or-fifteen solution) 4)
+   (check-equal? (evaluate fourteen-or-seven solution) 14)))
+
+(time (run-tests gen-concrete-tests))
+(time (run-tests gen-symbolic-tests))


### PR DESCRIPTION
Did not support the #:defined-table option, because I'm pretty sure that option does not work in Racket itself. I ran all-rosette-tests.rkt and they all passed.