### PR TITLE
Fix unbound identifier error in define-synthax example

### DIFF
--- a/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
+++ b/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
@@ -88,7 +88,7 @@ The hole @racket[(id e ... k)] must specify the inlining bound
 (eval:no-prompt
  (code:comment "The body of nnf=> is a hole to be filled with an")
  (code:comment "expression of depth (up to) 1 from the NNF grammar.")
- (define (nnf=> a b)
+ (define (nnf=> x y)
    (nnf x y 1)))
 (define-symbolic a b boolean?)
 (eval:alts
@@ -96,7 +96,7 @@ The hole @racket[(id e ... k)] must specify the inlining bound
   (synthesize
    #:forall (list a b)
    #:guarantee (assert (equal? (=> a b) (nnf=> a b)))))
- `(define (nnf=> x y) (,|| (! a) b)))
+ `(define (nnf=> x y) (|| (! x) y)))
 ]
 
 Since @racket[define-synthax] uses macros to implement recursive grammars, 


### PR DESCRIPTION
As is, running the example gives the following error:

    ../../../Library/Racket/6.5/pkgs/rosette/rosette/lib/synthax/form.rkt:16:32: x: unbound identifier in module in: x

If the `define-symbolic` were in the file (i.e. not run in the prompt), `nnf=>` would need to be

    (define (nnf=> x y)
        (nnf a b 1)))

in order to get the sample output.

(Ras sent me here)