### PR TITLE
fix printing of symbolic values within lists

### DIFF
--- a/rosette/base/core/term.rkt
+++ b/rosette/base/core/term.rkt
@@ -52,6 +52,7 @@
    ord)                ; integer?  
   #:methods gen:typed 
   [(define (get-type v) (term-type v))]
+  #:property prop:custom-print-quotable 'never
   #:methods gen:custom-write
   [(define (write-proc self port mode)
      (fprintf port "~a" (term->string self)))])


### PR DESCRIPTION
This uses [`prop:custom-print-quotable`][prop:custom-print-quotable] to fix printing of symbolic values within lists and other maybe-quotable data structures. 

This causes values like `(list i)` to print as `(list i)` instead of `'(i)`, to indicate that it's a symbolic value instead of a concrete list of a concrete symbol. 
```racket
> (define-symbolic i integer?)
> (list i)
(list i)
> (list (+ i 1))
(list (+ i 1))
```
This is instead of `'(i)` and `'((+ i 1))`.

  [prop:custom-print-quotable]: http://docs.racket-lang.org/reference/Printer_Extension.html?q=custom-print-quotable#%28def._%28%28quote._~23~25kernel%29._prop~3acustom-print-quotable%29%29