### PR TITLE
query/debug.rkt: use the outer stx object instead of proc

### DIFF
--- a/rosette/query/debug.rkt
+++ b/rosette/query/debug.rkt
@@ -35,7 +35,7 @@
     [(_ proc arg ...) 
      (quasisyntax/loc stx
        (call-with-values (thunk (#%app proc arg ...))
-                         (relax-values (syntax/source proc))))]))
+                         (relax-values (syntax/source #,stx))))]))
 
 (define-syntax-rule (protect expr)
   (syntax-parameterize ([app (syntax-rules () [(_ proc arg (... ...)) (#%app proc arg (... ...))])])


### PR DESCRIPTION
Fixes https://github.com/emina/rosette/issues/40