### PR TITLE
use quote-syntax/keep-srcloc instead of syntax/source to avoid taint problems

### DIFF
--- a/rosette/query/debug.rkt
+++ b/rosette/query/debug.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require (for-syntax racket/syntax) racket/stxparam 
+(require (for-syntax racket/syntax) racket/stxparam syntax/quote
          (only-in "core.rkt" current-solver ∃-debug eval/asserts)
          "../lib/util/syntax-properties.rkt"
          (only-in "../base/form/app.rkt" app)
@@ -35,7 +35,7 @@
     [(_ proc arg ...) 
      (quasisyntax/loc stx
        (call-with-values (thunk (#%app proc arg ...))
-                         (relax-values (syntax/source #,stx))))]))
+                         (relax-values (quote-syntax/keep-srcloc proc))))]))
 
 (define-syntax-rule (protect expr)
   (syntax-parameterize ([app (syntax-rules () [(_ proc arg (... ...)) (#%app proc arg (... ...))])])


### PR DESCRIPTION
The previous commit 36d6465f52bb7d41d249b785d3f9b62977585d74, even though it fixed our source location issues, changed the behavior of the FSM demo so this PR reverts the change.

Instead, this PR uses the Racket's `quote-syntax/keep-srcloc` instead of `syntax/source` to save the source location in `query/debug`. This enables us to work around the source location issues without introducing taint errors.

All the tests (`all-rosette` and `all-sdsl`) pass, and the FSM demo behaves as it did before (ie, in b89ef6c75ed948c015a3487919e8fc148a4d45cc).