### PR TITLE
Remove bad comment

### DIFF
--- a/rosette/doc/guide/scribble/forms/racket-forms.scrbl
+++ b/rosette/doc/guide/scribble/forms/racket-forms.scrbl
@@ -31,7 +31,7 @@
 @(define sequencing (select '(begin begin0 begin-for-syntax)))
 @(define guarded-eval (select '(when unless)))
 @(define assignment (select '(set! set!-values)))
-@(define quasiquoting (select '(quasiquote unquote))); unquote-splicing)))
+@(define quasiquoting (select '(quasiquote unquote)))
 @(define syntax-quoting (select '(quote-syntax)))
 
 @(define rosette-eval (rosette-evaluator))


### PR DESCRIPTION
To comment in Scribble, it should be `@; ...` or `@;{ ... }`. Otherwise, it will appear as text.