### PR TITLE
Make symbolics more efficient

### DIFF
--- a/rosette/base/core/bitvector.rkt
+++ b/rosette/base/core/bitvector.rkt
@@ -700,9 +700,9 @@
       [(v (union ts))
        (merge+ (for/list ([gt ts] #:when (bitvector? (cdr gt)))
                  (cons (car gt) (integer->bitvector v (cdr gt))))
-               #:unless (length ts) #:error (arguments-error "expected a bitvector type t" "t" @t))]
+               #:unless (length ts) #:error (arguments-error 'integer->bitvector "expected a bitvector type t" "t" @t))]
       [(v (? bitvector? t)) (integer->bitvector v t)]
-      [(_ _) (assert #f (arguments-error "expected a bitvector type t" "t" @t))])))
+      [(_ _) (assert #f (arguments-error 'integer->bitvector "expected a bitvector type t" "t" @t))])))
 
 (define-operator @bitvector->integer
   #:identifier 'bitvector->integer

--- a/rosette/base/core/reflect.rkt
+++ b/rosette/base/core/reflect.rkt
@@ -18,30 +18,26 @@
 (define (symbolics vs)
   (match vs
     [(list (? constant?) ...) vs]
-    [_ (let ([cache (make-hash)])
+    [_ (let ([cache (mutable-set)]
+             [result '()])
          (let loop ([vs vs])
-           (if (hash-has-key? cache vs)
-               (hash-ref cache vs)
-               (begin
-                (hash-set! cache vs '())
-                (let ([result
-                       (remove-duplicates 
-                        (match vs
-                          [(union (list (cons guard value) ...))   
-                           (append (append-map loop guard) (append-map loop value))]
-                          [(expression _ x ...) (append-map loop x)]
-                          [(? constant? v) (list v)]
-                          [(box v) (loop v)]
-                          [(? list?) (append-map loop vs)]
-                          [(cons x y) (append (loop x) (loop y))]
-                          [(vector v ...) (append-map loop v)]
-                          [(and (? typed?) (app get-type t)) 
-                           (match (type-deconstruct t vs)
-                             [(list (== vs)) '()]
-                             [components (append-map loop components)])]
-                          [_ '()]))])
-                  (hash-set! cache vs result)
-                  result)))))]))
+           (unless (set-member? cache vs)
+             (set-add! cache vs)
+             (match vs
+               [(union (list (cons guard value) ...))
+                (for-each loop guard) (for-each loop value)]
+               [(expression _ x ...) (for-each loop x)]
+               [(? constant? v) (set! result (cons v result))]
+               [(box v) (loop v)]
+               [(? list?) (for-each loop vs)]
+               [(cons x y) (loop x) (loop y)]
+               [(vector v ...) (for-each loop v)]
+               [(and (? typed?) (app get-type t))
+                (match (type-deconstruct t vs)
+                  [(list (== vs)) (void)]
+                  [components (for-each loop components)])]
+               [_ (void)])))
+         result)]))
 
 (define (term->datum val)
   (let convert ([val val] [cache (make-hash)])

--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -138,25 +138,25 @@
          (syntax/loc stx 
            (begin
              (define-generics id . rest)
-             (lift-if-exists id? receiver)
-             (lift-if-exists support-name receiver)
-             (lift-if-exists method-name receiver) ...))))]))
+             (lift-if-exists id?)
+             (lift-if-exists support-name)
+             (lift-if-exists method-name) ...))))]))
     
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
     (make-struct-type-property name guard supers can-impersonate?))
-  (values prop:p (lift p? self) (lift p-ref self)))
+  (values prop:p (lift p?) (lift p-ref)))
 
 (define-syntax (lift-if-exists stx)
   (syntax-case stx ()
-    [(_ proc receiver)
+    [(_ proc)
      (if (syntax->datum #'proc)
          (syntax/loc stx
-           (set! proc (lift proc receiver)))
+           (set! proc (lift proc)))
          (syntax/loc stx
            (void)))]))
 
-(define-syntax-rule (lift proc receiver)
+(define-syntax-rule (lift proc)
   (let ([proc proc])
     (procedure-rename
      (lambda (receiver . args)

--- a/rosette/base/struct/generics.rkt
+++ b/rosette/base/struct/generics.rkt
@@ -116,7 +116,17 @@
                   (hash-ref options 'derived '()))]
       [other
        (wrong-syntax #'other
-                     "expected a list of arguments with no dotted tail")])))
+                     "expected a list of arguments with no dotted tail")]))
+
+  (define (index-of name-stx formals-stx)
+    (let* ([name (syntax->datum name-stx)]
+           [formals (syntax->datum formals-stx)])
+      (let loop ([i 0] [formals formals])
+        (cond [(not (pair? formals))
+               (wrong-syntax #'other "cannot tell where the generic type is")]
+              [(eq? name (car formals))
+               (datum->syntax name-stx i)]
+              [else (loop (+ i 1) (cdr formals))])))))
 
 (define-syntax (@define-generics stx)
   (syntax-case stx ()
@@ -133,36 +143,40 @@
                        "#:defined-table option is not supported in Rosette"))
 
        (with-syntax ([id? (format-id #'id "~a?" #'id #:source #'id)]
-                     [((method-name . dummy) ...) methods]
+                     [((method-name . method-args) ...) methods]
                      [support-name support])
-         (syntax/loc stx 
-           (begin
-             (define-generics id . rest)
-             (lift-if-exists id?)
-             (lift-if-exists support-name)
-             (lift-if-exists method-name) ...))))]))
+         (with-syntax ([(method-index ...)
+                        (map (lambda (args) (index-of #'id args))
+                             (syntax-e #'(method-args ...)))])
+           (syntax/loc stx 
+             (begin
+               (define-generics id . rest)
+               (lift-if-exists id? 0)
+               (lift-if-exists support-name 0)
+               (lift-if-exists method-name method-index) ...)))))]))
     
 (define (@make-struct-type-property name [guard #f] [supers null] [can-impersonate? #f])
   (define-values (prop:p p? p-ref) 
     (make-struct-type-property name guard supers can-impersonate?))
-  (values prop:p (lift p?) (lift p-ref)))
+  (values prop:p (lift p? 0) (lift p-ref 0)))
 
 (define-syntax (lift-if-exists stx)
   (syntax-case stx ()
-    [(_ proc)
+    [(_ proc receiver-index)
      (if (syntax->datum #'proc)
          (syntax/loc stx
-           (set! proc (lift proc)))
+           (set! proc (lift proc receiver-index)))
          (syntax/loc stx
            (void)))]))
 
-(define-syntax-rule (lift proc)
+(define-syntax-rule (lift proc receiver-index)
   (let ([proc proc])
     (procedure-rename
-     (lambda (receiver . args)
-      (if (union? receiver)
-          (for/all ([r receiver]) (apply proc r args))
-          (apply proc receiver args)))
+     (lambda args
+       (define receiver (list-ref args receiver-index))
+       (if (union? receiver)
+           (for/all ([r receiver]) (apply proc (list-set args receiver-index r)))
+           (apply proc args)))
      (or (object-name proc) 'proc))))
 
 #|


### PR DESCRIPTION
I'm running into an issue (https://github.com/uwplse/syncro/issues/11) where `symbolics` is taking a while to run because it relies heavily on `append`, so I've reimplemented it to build up a result list using only `cons`.

There are also a few other minor refactors I made a long time ago that I never actually merged. One adds a missing argument to bitvector error messages and the other removes some unnecessary arguments in generics (which was bad code that I originally wrote based on a misunderstanding of other Rosette code).

I ran `all-rosette-tests.rkt` and `all-sdsl-tests.rkt` and they both passed.