### PR TITLE
Bug fix: Flatten

### DIFF
--- a/rosette/base/adt/list.rkt
+++ b/rosette/base/adt/list.rkt
@@ -423,7 +423,8 @@
 (define @cons? @pair?)
 
 (define @flatten
-  (match-lambda [(union vs) (merge** vs flatten)]
+  (match-lambda [(union vs) (merge** vs @flatten)]
+                [(cons x y) (@append (@flatten x) (@flatten y))]
                 [other (flatten other)]))
 
 (define @append*

--- a/test/base/list.rkt
+++ b/test/base/list.rkt
@@ -91,6 +91,11 @@
   (check-equal? (@flatten (list 1 (list 2) 3)) (flatten '(1 (2) 3)))
   (check-equal? (@flatten 'a) (flatten 'a))
   (check-equal? (@flatten l0) l0)
+  (check-equal? (@flatten (merge a '(1) '((((#f)))))) `(,(merge a 1 #f)))
+  (check-equal? (@flatten (merge a '(1 2 (3 4)) '(1 2 (#f 4)))) `(1 2 ,(merge a 3 #f) 4))
+  (check-equal? (@flatten (merge a '(1 2 (3 4)) '(1 2 ((#f) 4)))) `(1 2 ,(merge a 3 #f) 4))
+  (check-union? (@flatten (merge a '(1 2 (3 4)) '(1 2 ((3 3) 4)))) {[a '(1 2 3 4)] [(! a) '(1 2 3 3 4)]})
+  (check-equal? (@flatten (merge a '((1 . 2) (((3) 4))) '(((1) 2 #f) . 4))) `(1 2 ,(merge a 3 #f) 4))
   (check-union? (@flatten (merge a '(1 (2) 3) '(4 . 5))) {[a '(1 2 3)] [(! a) '(4 5)]}))
  
 


### PR DESCRIPTION
Fixes a bug where `flatten` would not work on lists that contained symbolic unions.

The fix is simple but inefficient -- it seems likely that a more involved implementation that performed an inorder traversal with an accumulator visiting `cdr`s first would perform better. However, that seems sufficiently error prone to justify using the simple approach.