### PR TITLE
Fixes for Racket 7

### DIFF
--- a/rosette/lib/roseunit.rkt
+++ b/rosette/lib/roseunit.rkt
@@ -24,7 +24,7 @@
                 (module+ #,i
                   (run-all-tests
                    #,@(for/list ([m (syntax->list #'(mod ...))])
-                        (syntax-case m ()
+                        (syntax-case m (submod)
                           [(submod name) (quasisyntax/loc m (submod name #,i))]
                           [_ m]))))))))]))
 

--- a/rosette/lib/synthax/core.rkt
+++ b/rosette/lib/synthax/core.rkt
@@ -90,7 +90,7 @@
                 (let ([ctx (cons (identifier->tag (syntax/source call)) (static-context))])
                   (syntax-parameterize ([static-context (syntax-id-rules () [_ ctx])])
                                        (in-context ctx
-                                                   (thunk #,(if (<= (eval #'k) 0) 
+                                                   (thunk #,(if (<= (eval #'k (make-base-namespace)) 0)
                                                                 (syntax/source e0) 
                                                                 (syntax/source ek)))))))]))                    
          (free-id-table-set! codegen #'id (cons #'id id-gen))))]


### PR DESCRIPTION
These two fixes make the tests build and pass on Racket 7.

- Correctly bind `submod` in roseunit
- Evaluate synthax bounds in the base namespace