### PR TITLE
Expose per-solver options and allow solvers to be cloned

### DIFF
--- a/rosette/safe.rkt
+++ b/rosette/safe.rkt
@@ -28,7 +28,7 @@
   (current-solver (z3)))
 
 (provide
- (except-out (all-from-out "solver/solver.rkt") prop:solver-constructor solver-constructor? solver-constructor)
+ (except-out (all-from-out "solver/solver.rkt") prop:solver-constructor solver-constructor)
  (all-from-out  
   "solver/solution.rkt" 
   "base/base.rkt"

--- a/rosette/solver/mip/cplex.rkt
+++ b/rosette/solver/mip/cplex.rkt
@@ -36,7 +36,7 @@
       [else
        (define real-cplex-path (find-cplex path))
        (when (and (false? real-cplex-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
-         (error 'boolector "cplex binary is not available (expected to be at ~a); try passing the #:path argument to (cplex)" (path->string (simplify-path cplex-path))))
+         (error 'cplex "cplex binary is not available (expected to be at ~a); try passing the #:path argument to (cplex)" (path->string (simplify-path cplex-path))))
        (values real-cplex-path
                (hash-ref options 'verbose #f)
                (hash-ref options 'timeout #f))]))

--- a/rosette/solver/mip/cplex.rkt
+++ b/rosette/solver/mip/cplex.rkt
@@ -115,6 +115,8 @@
      '(qf_lia qf_lra))
    
    (define (solver-assert self bools)
+     (unless (list? bools)
+       (raise-argument-error 'solver-assert "(listof boolean?)" bools))
      (set-cplex-asserts! self 
       (append (cplex-asserts self)
               (for/list ([b bools] #:unless (equal? b #t))

--- a/rosette/solver/mip/server.rkt
+++ b/rosette/solver/mip/server.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require (only-in rosette sat unsat) racket/file)
-(provide server server-run)
+(provide server server-run server-path)
 
 (struct server (path opts))
 

--- a/rosette/solver/smt/base-solver.rkt
+++ b/rosette/solver/smt/base-solver.rkt
@@ -38,6 +38,8 @@
 
 
 (define (solver-assert self bools [wfcheck #f])
+  (unless (list? bools)
+    (raise-argument-error 'solver-assert "(listof boolean?)" bools))
   (define wfcheck-cache (mutable-set))
   (set-solver-asserts! self 
     (append (solver-asserts self)

--- a/rosette/solver/smt/base-solver.rkt
+++ b/rosette/solver/smt/base-solver.rkt
@@ -20,17 +20,21 @@
     [else (or (find-executable-path binary) #f)]))
 
 
-(define (make-send-options opts)
+(define (make-send-options conf)
+  (match-define (config options _ logic) conf)
   (lambda (server)
     (server-write server
-      (when (hash-has-key? opts 'logic)
-        (set-logic (hash-ref opts 'logic)))
-      (for ([opt (in-list (sort (hash-keys opts) symbol<?))] #:unless (eq? opt 'logic))
-        (set-option opt (hash-ref opts opt))))))
+      (unless (false? logic)
+        (set-logic logic))
+      (for ([opt (in-list (sort (hash-keys options) symbol<?))])
+        (set-option opt (hash-ref options opt))))))
 
 
-(struct solver (server options asserts mins maxs env level)
+(struct solver (server config asserts mins maxs env level)
   #:mutable)
+
+
+(struct config (options path logic))
 
 
 (define (solver-assert self bools [wfcheck #f])
@@ -93,6 +97,8 @@
 (define (solver-debug self)
   (error 'solver-debug "debugging isn't supported by solver ~v" self))
 
+(define (solver-options self)
+  (config-options (solver-config self)))
 
 (define (solver-clear-stacks! self)
   (set-solver-asserts! self '())

--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -23,7 +23,7 @@
 (define (make-boolector [solver #f] #:options [options (hash)] #:logic [logic #f] #:path [path #f])
   (define config
     (cond
-      [solver
+      [(boolector? solver)
        (base/solver-config solver)]
       [else
        (define real-boolector-path (base/find-solver "boolector" boolector-path (hash-ref options 'path #f)))

--- a/rosette/solver/smt/cvc4.rkt
+++ b/rosette/solver/smt/cvc4.rkt
@@ -16,7 +16,7 @@
 (define (make-cvc4 [solver #f] #:options [options (hash)] #:logic [logic #f] #:path [path #f])
   (define config
     (cond
-      [solver
+      [(cvc4? solver)
        (base/solver-config solver)]
       [else
        (define real-cvc4-path (base/find-solver "cvc4" cvc4-path (hash-ref options 'path #f)))

--- a/rosette/solver/smt/server.rkt
+++ b/rosette/solver/smt/server.rkt
@@ -3,7 +3,7 @@
 (require racket/runtime-path racket/file)
 
 (provide server server-start server-running? server-shutdown 
-         server-write server-read server-error
+         server-write server-read server-error server-initialize
          output-smt printf/current-server)
 
 (define current-server (make-parameter #f))
@@ -62,8 +62,12 @@
       (define-values (p out in err) 
         (apply subprocess #f #f #f (server-path s) (server-opts s)))
       (set-server-values! s (current-custodian) p out in err (open-output-nowhere))
-      ((server-init s) s)))
+      (server-initialize s)))
   s)
+
+; Invoke the server's initialize procedure
+(define (server-initialize s)
+  ((server-init s) s))
 
 ; Initialize the server's log output if required
 (define (server-initialize-log s)

--- a/rosette/solver/smt/z3.rkt
+++ b/rosette/solver/smt/z3.rkt
@@ -24,7 +24,7 @@
 (define (make-z3 [solver #f] #:options [options (hash)] #:logic [logic #f] #:path [path #f])
   (define config
     (cond
-      [solver
+      [(z3? solver)
        (base/solver-config solver)]
       [else
        (define real-z3-path (base/find-solver "z3" z3-path path))

--- a/rosette/solver/smt/z3.rkt
+++ b/rosette/solver/smt/z3.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require racket/runtime-path 
+(require racket/runtime-path racket/hash
          "server.rkt" "cmd.rkt" "env.rkt" 
          "../solver.rkt" "../solution.rkt"
          (prefix-in base/ "base-solver.rkt")
@@ -15,11 +15,20 @@
 (define-runtime-path z3-path (build-path ".." ".." ".." "bin" "z3"))
 (define z3-opts '("-smt2" "-in"))
 
-(define (make-z3 #:path [path #f])
-  (define real-z3-path (base/find-solver "z3" z3-path path))
+(define default-options
+  (hash ':produce-unsat-cores 'false
+        ':auto-config 'true
+        ':smt.relevancy 2
+        ':smt.mbqi.max_iterations 10000000))
+
+(define (make-z3 [options-or-solver (hash)])
+  (define options (if (z3? options-or-solver) (base/solver-options options-or-solver) options-or-solver))
+  (define real-z3-path (base/find-solver "z3" z3-path (hash-ref options 'path #f)))
   (when (and (false? real-z3-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
     (printf "warning: could not find z3 executable at ~a\n" (path->string (simplify-path z3-path))))
-  (z3 (server real-z3-path z3-opts set-default-options) '() '() '() (env) '()))
+  (define opts (hash-union default-options options #:combine (lambda (a b) b)))
+  (define send-opts (hash-remove opts 'path))
+  (z3 (server real-z3-path z3-opts (base/make-send-options send-opts)) opts '() '() '() (env) '()))
   
 (struct z3 base/solver ()
   #:mutable
@@ -30,6 +39,9 @@
   [
    (define (solver-features self)
      '(qf_bv qf_uf qf_lia qf_nia qf_lra qf_nra quantifiers optimize unsat-cores))
+   
+   (define (solver-options self)
+     (base/solver-options self))
 
    (define (solver-assert self bools)
      (base/solver-assert self bools))
@@ -44,7 +56,7 @@
      (base/solver-clear-stacks! self)
      (base/solver-clear-env! self)
      (server-write (base/solver-server self) (reset))
-     (set-default-options (base/solver-server self)))
+     (server-initialize (base/solver-server self)))
    
    (define (solver-shutdown self)
      (solver-clear self)
@@ -60,7 +72,7 @@
      (base/solver-check self))
 
    (define (solver-debug self)
-     (match-define (z3 server (app unique asserts) _ _ _ _) self)
+     (match-define (z3 server _ (app unique asserts) _ _ _ _) self)
      (cond [(ormap false? asserts) (unsat (list #f))]
            [else (base/solver-clear-env! self)
                  (server-write (base/solver-server self) (reset))
@@ -70,13 +82,6 @@
                   (begin (encode-for-proof (base/solver-env self) asserts)
                          (check-sat)))
                  (base/read-solution server (base/solver-env self) #:unsat-core? #t)]))])
-
-(define (set-default-options server)
-  (server-write server
-    (set-option ':produce-unsat-cores 'false)
-    (set-option ':auto-config 'true)
-    (set-option ':smt.relevancy 2)
-    (set-option ':smt.mbqi.max_iterations 10000000)))
 
 (define (set-core-options server)
   (server-write server

--- a/rosette/solver/solver.rkt
+++ b/rosette/solver/solver.rkt
@@ -7,7 +7,7 @@
          solver-minimize solver-maximize
          solver-check solver-debug 
          solver-shutdown solver-features
-         prop:solver-constructor solver-constructor? solver-constructor
+         prop:solver-constructor solver-constructor
          )
 
 ; The generic solver interface specifies the set of procedures that 
@@ -50,6 +50,9 @@
 ;
 ; The solver-features procedure returns a list of symbol?s specifying the
 ; SMT features (logics, optimization, etc) a solver supports.
+;
+; The solver-options procedure returns a hash table of options the solver
+; is configured with (e.g., path to its binary).
 (define-generics solver
   [solver-assert solver bools]
   [solver-push solver]
@@ -60,12 +63,18 @@
   [solver-check solver]
   [solver-debug solver]
   [solver-shutdown solver]
-  [solver-features solver])
+  [solver-features solver]
+  [solver-options solver])
 
 ; Solvers should implement the prop:solver-constructor type property
 ; to provide the procedure used to construct new solvers of the same type.
 ; Query forms will use this property to spawn new solvers when necessary
 ; (e.g., synthesize needs two solvers).
 (define-values
-  (prop:solver-constructor solver-constructor? solver-constructor)
+  (prop:solver-constructor solver-constructor? get-solver-constructor)
   (make-struct-type-property 'solver-constructor))
+
+(define (solver-constructor solver)
+  (case-lambda
+    [() ((get-solver-constructor solver) (solver-options solver))]
+    [(opts) ((get-solver-constructor solver) opts)]))

--- a/rosette/solver/solver.rkt
+++ b/rosette/solver/solver.rkt
@@ -52,7 +52,7 @@
 ; SMT features (logics, optimization, etc) a solver supports.
 ;
 ; The solver-options procedure returns a hash table of options the solver
-; is configured with (e.g., path to its binary).
+; is configured with.
 (define-generics solver
   [solver-assert solver bools]
   [solver-push solver]
@@ -75,6 +75,8 @@
   (make-struct-type-property 'solver-constructor))
 
 (define (solver-constructor solver)
-  (case-lambda
-    [() ((get-solver-constructor solver) (solver-options solver))]
-    [(opts) ((get-solver-constructor solver) opts)]))
+  (make-keyword-procedure
+    (lambda (kws kw-args . rest)
+      (keyword-apply (get-solver-constructor solver) kws kw-args rest))
+    (lambda args
+      (apply (get-solver-constructor solver) solver args))))


### PR DESCRIPTION
With this commit, we can access SMT `set-logic`:

    (require rosette/solver/smt/z3)
    (z3 #:logic 'QF_BV)

(Rosette makes no effort to check that constraints are actually in the specified logic).

We can also access SMT `set-option`:

    (z3 #:options (hash ':smt.relevancy 0))

Finally, we can create a new solver that clones an existing solver's settings (used in CEGIS to duplicate the `current-solver`):

    (define s1 (z3 #:logic 'QF_BV))
    (define s2 (z3 s1))