### PR TITLE
Use the User-Provided Solver Paths

### DIFF
--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -35,7 +35,7 @@
 (struct boolector base/solver ()
   #:property prop:solver-constructor make-boolector
   #:methods gen:custom-write
-  [(define (write-proc self port mode) (fprintf port "#<cvc4>"))]
+  [(define (write-proc self port mode) (fprintf port "#<boolector>"))]
   #:methods gen:solver
   [
    (define (solver-features self)

--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -26,7 +26,7 @@
       [(boolector? solver)
        (base/solver-config solver)]
       [else
-       (define real-boolector-path (base/find-solver "boolector" boolector-path (hash-ref options 'path #f)))
+       (define real-boolector-path (base/find-solver "boolector" boolector-path path))
        (when (and (false? real-boolector-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
          (error 'boolector "boolector binary is not available (expected to be at ~a); try passing the #:path argument to (boolector)" (path->string (simplify-path boolector-path))))
        (base/config options real-boolector-path logic)]))

--- a/rosette/solver/smt/cvc4.rkt
+++ b/rosette/solver/smt/cvc4.rkt
@@ -19,7 +19,7 @@
       [(cvc4? solver)
        (base/solver-config solver)]
       [else
-       (define real-cvc4-path (base/find-solver "cvc4" cvc4-path (hash-ref options 'path #f)))
+       (define real-cvc4-path (base/find-solver "cvc4" cvc4-path path))
        (when (and (false? real-cvc4-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
          (error 'cvc4 "cvc4 binary is not available (expected to be at ~a); try passing the #:path argument to (cvc4)" (path->string (simplify-path cvc4-path))))
        (base/config options real-cvc4-path logic)]))

--- a/rosette/solver/smt/yices.rkt
+++ b/rosette/solver/smt/yices.rkt
@@ -69,7 +69,7 @@
      (base/solver-debug self))])
 
 
-; Check whether a term v is well-formed for Boolector -- it must not 
+; Check whether a term v is well-formed for Yices -- it must not 
 ; use integer->bitvector, which Yices doesn't support natively,
 ; nor a quantifier.
 (define (yices-wfcheck v [cache (mutable-set)])

--- a/rosette/solver/smt/yices.rkt
+++ b/rosette/solver/smt/yices.rkt
@@ -23,7 +23,7 @@
       [(yices? solver)
        (base/solver-config solver)]
       [else
-       (define real-yices-path (base/find-solver "yices" yices-path (hash-ref options 'path #f)))
+       (define real-yices-path (base/find-solver "yices" yices-path path))
        (when (and (false? real-yices-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
          (error 'yices "yices binary is not available (expected to be at ~a); try passing the #:path argument to (yices)" (path->string (simplify-path yices-path))))
        (base/config options real-yices-path logic)]))


### PR DESCRIPTION
I discovered the Boolector constructor wasn't using the path as provided by the `#:path` keyword argument, instead it was looking in the `#:options` dict argument. 

In the end, three solvers were doing this, and only z3 and CPLEX were actually using the `#:path` argument. Now all solvers use the `#:path` argument correctly, in line with their error messages.

I also saw a comment that was wrong, and corrected it.