### PR TITLE
add contracts to print-forms and generate-forms

### DIFF
--- a/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
+++ b/rosette/doc/guide/scribble/libs/rosette-libs.scrbl
@@ -149,13 +149,13 @@ always refers to the same hole, as shown below.
       (assert (= (+ (* x 2) (* y 1)) (+ (* 2 x) y))))))]
 }
 
-@defproc[(generate-forms [solution solution?]) (listof syntax?)]{
+@defproc[(generate-forms [solution sat?]) (listof syntax?)]{
 Given a satisfiable @racket[solution?] to a @racket[synthesize]  query,
 returns a list of @tech{sketch} completions for that query.  
 Sketch completions can only be generated for programs that have been saved to disk.  
 }
 
-@defproc[(print-forms [solution solution?]) void?]{
+@defproc[(print-forms [solution sat?]) void?]{
   Pretty-prints the result of applying @racket[generate-forms] to the given  
   @racket[solution]. Sketch completions can only be generated and printed
  for programs that have been saved to disk. 

--- a/rosette/lib/synthax/core.rkt
+++ b/rosette/lib/synthax/core.rkt
@@ -4,9 +4,12 @@
          (for-syntax "../util/syntax-properties.rkt")  
          "../util/syntax-properties.rkt"
          (only-in rosette/lib/util/syntax read-module)
-         (only-in rosette constant model term-cache))
+         (only-in rosette constant model term-cache sat?))
 
-(provide hole completion define-synthax generate-forms print-forms)
+(provide hole completion define-synthax
+         (contract-out
+          [generate-forms (-> sat? (listof syntax?))]
+          [print-forms (-> sat? any)]))
 
 ; Stores the current synthax-expansion context, represented 
 ; as a list of tags, where the most recent tag identifies the 


### PR DESCRIPTION
Currently when `print-forms` and `generate-forms` are given an `unsat?` they given an internal error message in terms of `sat-model`. This PR add contracts to them, and updates the docs to specify that new contract.

Example:

```
#lang rosette/safe
(require rosette/lib/synthax)

(define res
  (synthesize
   #:forall (list)
   #:guarantee (assert #f)))

(print-forms res)
```

Now raises:

```
print-forms: contract violation
  expected: sat?
  given: (unsat)
  in: the 1st argument of
      (-> sat? any)
  contract from: 
      <pkgs>/rosette/rosette/lib/synthax/core.rkt
  blaming: this-file.rkt
   (assuming the contract is correct)
```

Instead of:
```
rosette/rosette/lib/synthax/core.rkt:163:0: sat-model: contract violation
  expected: sat?
  given: (unsat)
```