### PR TITLE
Macrology and optimization for for/all

### DIFF
--- a/rosette/base/core/forall.rkt
+++ b/rosette/base/core/forall.rkt
@@ -110,9 +110,7 @@
        (when (null? guards) (assert #f all-path-infeasible))
        (when (ormap pair? states)
          (merge-states guards states))
-       (apply merge* (map cons guards outputs))]))
-
-  )
+       (apply merge* (map cons guards outputs))])))
   
 ; Speculatively executes the given procedure on the provided 
 ; guarded values and returns three lists---guards, outputs, 

--- a/rosette/doc/guide/scribble/reflection/value-reflection.scrbl
+++ b/rosette/doc/guide/scribble/reflection/value-reflection.scrbl
@@ -183,7 +183,7 @@ to lift operations on @tech[#:key "unsolvable type"]{unsolvable types}.  The
 @declare-exporting[rosette/base/core/forall rosette/lib/lift
                    #:use-sources (rosette/base/core/forall rosette/lib/lift)]
 
-@defform[(for/all ([id val-expr]) body)]{
+@defform[(for/all ([id val-expr]) body ...+)]{
 If @racket[val-expr] evaluates to a value that is not a @racket[union?], 
 @racket[for/all] behaves like a @racket[let] expression.  It binds 
 @racket[id] to the value and evaluates the @racket[body] with that binding.  
@@ -250,7 +250,7 @@ Experimenting is the best way to determine whether and where to insert
 performance-guiding @racket[for/all]s.
 }]}
 
-@defform[(for*/all ([id val-expr] ...+) body)]{
+@defform[(for*/all ([id val-expr] ...+) body ...+)]{
 Expands to a nested use of @racket[for/all], 
 just like @racket[let*] expands to a nested use of @racket[let].}                                             
                                     


### PR DESCRIPTION
- Support multiple expressions in the body of for/all and for*/all
- Optimize for/all with concrete list when the value is also concrete.
  In that case, there's no need to perform speculation which is expensive:

Before:

```
> (time (for/all ([x 1 (range 1 10000)]) 1))
cpu time: 75 real time: 75 gc time: 14
```

After:

```
> (time (for/all ([x 1 (range 1 10000)]) 1))
cpu time: 12 real time: 12 gc time: 0
```