### PR TITLE
Update support for Boolector 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - RACKET_DIR=~/racket
     - CVC4_URL="http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/cvc4-1.5-x86_64-linux-opt"
-    - BOOLECTOR_URL="http://fmv.jku.at/boolector/boolector-2.4.1-with-lingeling-bbc.tar.bz2"
+    - BOOLECTOR_URL="https://github.com/Boolector/boolector/archive/3.1.0.tar.gz"
   matrix:
     - RACKET_VERSION=6.9
     - RACKET_VERSION=7.0
@@ -26,10 +26,17 @@ before_install:
       mkdir bin &&
       wget $CVC4_URL -nv -O bin/cvc4 &&
       chmod +x bin/cvc4 &&
-      wget $BOOLECTOR_URL -nv -O boolector.tar.bz2 &&
-      tar xjf boolector.tar.bz2 &&
-      make -C boolector-* &&
-      cp boolector-*/boolector/bin/boolector bin/ &&
+      wget $BOOLECTOR_URL -nv -O boolector.tar.gz &&
+      mkdir boolector &&
+      tar xzf boolector.tar.gz -C boolector --strip-components=1 &&
+      pushd boolector &&
+      ./contrib/setup-cadical.sh &&
+      ./contrib/setup-btor2tools.sh &&
+      ./configure.sh &&
+      cd build &&
+      make &&
+      popd &&
+      cp boolector/build/bin/boolector bin/ &&
       rm -rf boolector*;
     fi
 

--- a/rosette/doc/guide/scribble/datatypes/solvers+solutions.scrbl
+++ b/rosette/doc/guide/scribble/datatypes/solvers+solutions.scrbl
@@ -261,7 +261,7 @@ without its optional @racket[path] argument.}
            [(boolector? [v any/c]) boolean?])]{
 Returns a @racket[solver?] wrapper for the @hyperlink["http://fmv.jku.at/boolector/"]{Boolector} solver from JKU.
 
-To use this solver, download and install Boolector,
+To use this solver, download and install Boolector (version 2.4.1 or later),
 and either add the @tt{boolector} executable to your @tt{PATH}
 or pass the path to the executable as the optional @racket[path] argument.
 
@@ -307,7 +307,7 @@ will send the command @tt{(set-option :random-seed 5)} to Yices prior to solving
 }
 
 @defproc[(yices-available?) boolean?]{
-Returns true if the yices solver is available for use (i.e., Rosette can locate a @tt{yices-smt2} binary).
+Returns true if the Yices solver is available for use (i.e., Rosette can locate a @tt{yices-smt2} binary).
 If this returns @racket[#f], @racket[(yices)] will not succeed
 without its optional @racket[path] argument.}
 


### PR DESCRIPTION
Support the different behavior for renaming variables in incremental mode, and for booleans to only sometimes be replaced with 1-bit bitvectors.

Boolector 3.x supports quantifiers but not combining quantifiers with UFs, so we leave quantifier support disabled.