### PR TITLE
Build latest Racket release (both 3m and CS) in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     - CVC4_URL="http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/cvc4-1.5-x86_64-linux-opt"
     - BOOLECTOR_URL="https://github.com/Boolector/boolector/archive/3.1.0.tar.gz"
   matrix:
-    - RACKET_VERSION=6.9
-    - RACKET_VERSION=7.0
-    - RACKET_VERSION=7.2
+    - RACKET_VERSION=6.9  # Our minimum supported version
+    - RACKET_VERSION=RELEASE
+    - RACKET_VERSION=RELEASECS
     - RACKET_VERSION=HEAD
-    - RACKET_VERSION=7.2 ALL_SOLVERS=1
+    - RACKET_VERSION=RELEASE ALL_SOLVERS=1
 
 matrix:
   allow_failures:


### PR DESCRIPTION
`RELEASE` means we'll build against the latest pre-release snapshot, which will be the soon-to-be-released version when Racket is inside a release window, and current version otherwise.