### PR TITLE
add gui-lib and gui-doc deps

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -9,11 +9,13 @@
                "web-server-lib"
                "rackunit-lib"
                "slideshow-lib"
+               "gui-lib"
                "base"))
 
 (define build-deps '("pict-doc"
                      "scribble-lib"
                      "racket-doc"
+                     "gui-doc"
                      "errortrace-doc"))
 
 (define test-omit-paths (if (getenv "PLT_PKG_BUILD_SERVICE") 'all '()))


### PR DESCRIPTION
I'm getting an "undeclared dependencies" error from rosette after running `raco setup`.

I think these might be used by the new value browser?