### PR TITLE
Work around bug in Racket's get-pure-port redirection

### DIFF
--- a/rosette/private/install.rkt
+++ b/rosette/private/install.rkt
@@ -54,3 +54,52 @@
       "z3-d89c39cb-x64-win")]
     [any
      (raise-user-error 'get-z3-url "Unknown system type '~a'" any)]))
+
+;; A copy of net/url's get-pure-port/headers, except with the Location header
+;; for redirects made case-insensitive, fixing https://github.com/racket/racket/pull/3057
+(require net/http-client net/url-connect)
+(define (get-pure-port url #:redirections [redirections 0])
+  (let redirection-loop ([redirections redirections] [url url])
+    (define hc (http-conn-open (url-host url)
+                               #:ssl? (if (equal? "https" (url-scheme url))
+                                          (current-https-protocol)
+                                          #f)))
+    (define access-string
+      (url->string
+       ;; RFCs 1945 and 2616 say:
+       ;;   Note that the absolute path cannot be empty; if none is present in
+       ;;   the original URI, it must be given as "/" (the server root).
+       (let-values ([(abs? path)
+                     (if (null? (url-path url))
+                         (values #t (list (make-path/param "" '())))
+                         (values (url-path-absolute? url) (url-path url)))])
+         (make-url #f #f #f #f abs? path (url-query url) (url-fragment url)))))
+    (http-conn-send! hc access-string #:method #"GET" #:content-decode '())
+    (define-values (status headers response-port)
+      (http-conn-recv! hc #:method #"GET" #:close? #t #:content-decode '()))
+
+    (define new-url
+      (ormap (λ (h)
+               (match (regexp-match #rx#"^[Ll]ocation: (.*)$" h)
+                 [#f #f]
+                 [(list _ m1b)
+                  (define m1 (bytes->string/utf-8 m1b))
+                  (with-handlers ((exn:fail? (λ (x) #f)))
+                    (define next-url (string->url m1))
+                    (make-url
+                     (or (url-scheme next-url) (url-scheme url))
+                     (or (url-user next-url) (url-user url))
+                     (or (url-host next-url) (url-host url))
+                     (or (url-port next-url) (url-port url))
+                     (url-path-absolute? next-url)
+                     (url-path next-url)
+                     (url-query next-url)
+                     (url-fragment next-url)))]))
+             headers))
+    (define redirection-status-line?
+      (regexp-match #rx#"^HTTP/[0-9]+[.][0-9]+ 3[0-9][0-9]" status))
+    (cond
+      [(and redirection-status-line? new-url (not (zero? redirections)))
+       (redirection-loop (- redirections 1) new-url)]
+      [else
+       response-port])))


### PR DESCRIPTION
The Rosette installer downloads Z3 from a GitHub release, and GitHub release URLs redirect to a CDN, so we use `get-pure-port`'s `#:redirections` argument to follow those redirects. GitHub seems to have started using a lowercase "location" header for redirects sometimes (which the HTTP spec entitles it to do, but it is unusual). Racket only checks for the uppercase version. So we need to pull in that code and modify it to handle either version.

We've sent a PR to upstream Racket to fix this bug (https://github.com/racket/racket/pull/3057), but it will be a while before that propagates to end users, so we're going to need this fix for a while.