### PR TITLE
Update output format argument to Boolector

### DIFF
--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -15,7 +15,7 @@
 (provide (rename-out [make-boolector boolector]) boolector? boolector-available?)
 
 (define-runtime-path boolector-path (build-path ".." ".." ".." "bin" "boolector"))
-(define boolector-opts '("-m" "--smt2-model" "-i"))
+(define boolector-opts '("-m" "--output-format=smt2" "-i"))
 
 (define (boolector-available?)
   (not (false? (base/find-solver "boolector" boolector-path #f))))


### PR DESCRIPTION
The old version was [recently removed](https://github.com/Boolector/boolector/commit/2bde574a1467fb61f79caea388256445d9ef5312) as noticed by @xiw, and the new one is backwards compatible back to 3.0.0, our minimum version.

Starting a PR so we can make sure Travis approves.