### PR TITLE
Add node_modules to compile-omit-files

### DIFF
--- a/rosette/info.rkt
+++ b/rosette/info.rkt
@@ -16,7 +16,8 @@
 
 ;; Runs the code in `private/install.rkt` before installing this collection.
 (define pre-install-collection "private/install.rkt")
-(define compile-omit-files '("private/install.rkt"))
+(define compile-omit-files '("private/install.rkt"
+                             "lib/trace/report/node_modules"))
 
 (define raco-commands
   '(("symprofile"


### PR DESCRIPTION
Prevent raco setup / raco pkg from traversing through ~5000 directories
inside node_modules