### PR TITLE
Provide writeln and println from Racket

### DIFF
--- a/rosette/base/base.rkt
+++ b/rosette/base/base.rkt
@@ -164,7 +164,7 @@
  expand-syntax-to-top-form
  ; input and output
  read read-syntax
- write display print displayln fprintf printf eprintf format newline
+ write display print writeln displayln println fprintf printf eprintf format newline
  pretty-print pretty-write pretty-display pretty-format 
  call-with-input-file
  current-input-port current-output-port current-error-port eof


### PR DESCRIPTION
A tiny PR: re-export `writeln` and `println` from Racket.

(I was curious why these weren't included when `displayln` was, and it looks like the surrounding code providing `write` etc. was written before `writeln` and `println` existed)