### PR TITLE
Mark `bv` constants as not quotable

### DIFF
--- a/rosette/base/core/bitvector.rkt
+++ b/rosette/base/core/bitvector.rkt
@@ -88,6 +88,7 @@
   #:transparent
   #:methods gen:typed
   [(define (get-type self) (bv-type self))]
+  #:property prop:custom-print-quotable 'never
   #:methods gen:custom-write
   [(define (write-proc self port mode)
      (match self


### PR DESCRIPTION
Similar to #37, `bv`s need to be marked as not quotable, so that they round-trip through `print` and `eval` correctly.

This program prints a `(box (bv 0 5))` and then evals it:
```
#lang rosette

(define-namespace-anchor a)
(define ns (namespace-anchor->namespace a))

(define expr
  (with-input-from-string
   (with-output-to-string (thunk (print (box (bv 0 5)))))
    read))

(unbox (eval expr ns))
```

The unbox currently evaluates to `'(bv 0 5)`; this PR makes it evaluate to `(bv 0 5)` as expected.