### PR TITLE
Workaround a Racket CS bug

### DIFF
--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -103,7 +103,7 @@
 
 (define (exn-context->json xs)
   (for/list ([x (in-list xs)] [_limit (in-range 32)])
-    (hash 'name (when/null [name (car x)] (symbol->string name))
+    (hash 'name (when/null [name (car x)] (~a name))
           'srcloc (when/null [loc (cdr x)]
                     (hash 'source (normalize-path-for-rosette (srcloc-source loc))
                           'line (srcloc-line loc)


### PR DESCRIPTION
Racket doc guarantees that a procedure name in a "stack trace" will be a
symbol, but it's a string in Racket CS, causing a failure in the tracer.
This PR workarounds the problem.

Related: racket/racket#3398