### PR TITLE
Instrument define-values

### DIFF
--- a/test/trace/code/lib.rkt
+++ b/test/trace/code/lib.rkt
@@ -1,0 +1,9 @@
+#lang racket
+
+(require rosette)
+(provide mac)
+(define-syntax-rule (mac)
+  (begin
+    (begin
+      (define foo (verify (1)))
+      (define bar 1))))

--- a/test/trace/code/macro-define.rkt
+++ b/test/trace/code/macro-define.rkt
@@ -1,13 +1,4 @@
 #lang rosette
 
-(module lib racket
-  (require rosette)
-  (provide mac)
-  (define-syntax-rule (mac)
-    (begin
-      (begin
-        (define foo (verify (1)))
-        (define bar 1)))))
-
-(require 'lib)
+(require "lib.rkt")
 (mac)

--- a/test/trace/code/macro-define.rkt
+++ b/test/trace/code/macro-define.rkt
@@ -1,0 +1,13 @@
+#lang rosette
+
+(module lib racket
+  (require rosette)
+  (provide mac)
+  (define-syntax-rule (mac)
+    (begin
+      (begin
+        (define foo (verify (1)))
+        (define bar 1)))))
+
+(require 'lib)
+(mac)

--- a/test/trace/output/regular/macro-define.rkt.out
+++ b/test/trace/output/regular/macro-define.rkt.out
@@ -1,0 +1,6 @@
+((#:stats #hash((assertion . 0) (solver . 0)))
+ (#:trace
+  (("application: not a procedure;\n expected ...."
+    (#%app "macro-define.rkt" 9 28)
+    ((1 "macro-define.rkt" 9 28))
+    #t))))

--- a/test/trace/output/regular/macro-define.rkt.out
+++ b/test/trace/output/regular/macro-define.rkt.out
@@ -1,6 +1,6 @@
 ((#:stats #hash((assertion . 0) (solver . 0)))
  (#:trace
   (("application: not a procedure;\n expected ...."
-    (#%app "macro-define.rkt" 9 28)
-    ((1 "macro-define.rkt" 9 28))
+    (mac "macro-define.rkt" 4 1)
+    ()
     #t))))

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -106,6 +106,7 @@
                         "if.rkt"
                         "infeasible.rkt"
                         "macro.rkt"
+                        "macro-define.rkt"
                         "solver-limitation.rkt"
                         "test-track-form.rkt"
                         "error.rkt"


### PR DESCRIPTION
The current tracer fails when a macro expands to define-values
at the top level due to an erroneous assumption that define-values
could not result in an error, which is not true as demonstrated in
macro-define.rkt. This PR thus adds define-values to a list of forms
to instrument. Note that define-values is different from other forms
because it's not an expression, so it needs a special handling.
The change also requires us to manually keep track the inferred name.