### PR TITLE
with-continuation-mark based tracer

### DIFF
--- a/rosette/lib/trace/compile.rkt
+++ b/rosette/lib/trace/compile.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require syntax/parse syntax/stx racket/keyword-transform
+(require syntax/parse racket/keyword-transform
          (only-in "tool.rkt" add-original-form!)
          "../util/syntax.rkt")
 
@@ -362,8 +362,11 @@
 ;; Annotate a top-level expr
 (define trace-annotate
   (syntax-parser
-    [(_module _mod-id lang _module-begin)
-     #:when (ok-lang? (syntax-e #'lang))
+    [(mod:id _mod-id lang _module-begin)
+     #:when (and (free-identifier=? #'mod
+                                    (namespace-module-identifier)
+                                    (namespace-base-phase))
+                 (ok-lang? (syntax-e #'lang)))
      (printf "INSTRUMENTING ~v\n" (syntax-source this-syntax))
      (set-add! original-files (syntax-source this-syntax))
      (define expanded-e (expand-syntax

--- a/rosette/lib/trace/compile.rkt
+++ b/rosette/lib/trace/compile.rkt
@@ -30,8 +30,6 @@
 
 ;; Misc syntax munging stuff ---------------------------------------------------
 
-(define base-phase
-  (variable-reference->module-base-phase (#%variable-reference)))
 (define code-insp (variable-reference->module-declaration-inspector
                    (#%variable-reference)))
 
@@ -93,12 +91,6 @@
 
 
 ;; Core instrumentation procedure ----------------------------------------------
-
-;; Recursively annotate a lambda expression
-(define (annotate-lambda expr clause bodys-stx phase)
-  (let* ([bodys (stx->list bodys-stx)]
-         [bodyl (map (curryr annotate phase) bodys)])
-    (rebuild clause (map cons bodys bodyl))))
 
 ;; Recursively annotate a submodule
 (define (annotate-module expr disarmed-expr phase)

--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -105,6 +105,7 @@
   (match stack
     ['() '()]
     [(cons #f stack) (first-frame->json/tail stack)]
+    [(cons (list 'certified a b) _) #:when (equal? a b) '()]
     [(cons (list _ _ elem) _)
      (list (apply frame->json/tail elem))]))
 

--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -105,7 +105,7 @@
   (match stack
     ['() '()]
     [(cons #f stack) (first-frame->json/tail stack)]
-    [(cons (list 'certified a b) _) #:when (equal? a b) '()]
+    [(cons (list 'certified a b) _) #:when (eq? a b) '()]
     [(cons (list _ _ elem) _)
      (list (apply frame->json/tail elem))]))
 

--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -106,11 +106,13 @@
 (define (first-frame->json/tail stack)
   (match stack
     ['() '()]
+    [(cons #f stack) (first-frame->json/tail stack)]
     [(cons (list _ _ elem) _)
      (list (apply frame->json/tail elem))]))
 
 (define (each-frame->json/tail frame)
   (match frame
+    [#f #f]
     [(list 'uncertified _ _) #f]
     [(list _ elem _) (apply frame->json/tail elem)]))
 
@@ -140,7 +142,7 @@
         'callStack
         (cond
           [(symbolic-trace-tail?) (append (first-frame->json/tail stack)
-                                          (map each-frame->json/tail stack))]
+                                          (filter-map each-frame->json/tail stack))]
           [else
            ;; TODO
            (append (first-frame->json/tail stack)

--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -59,8 +59,6 @@
    (current-command-line-arguments (list->vector args))
    filename))
 
-(symbolic-trace-tail? #t)
-
 (collect-garbage)
 (collect-garbage)
 (collect-garbage)
@@ -140,13 +138,8 @@
                                         'line (third stx-info)
                                         'column (fourth stx-info))))
         'callStack
-        (cond
-          [(symbolic-trace-tail?) (append (first-frame->json/tail stack)
-                                          (filter-map each-frame->json/tail stack))]
-          [else
-           ;; TODO
-           (append (first-frame->json/tail stack)
-                   (map each-frame->json/tail stack))])))
+        (append (first-frame->json/tail stack)
+                (filter-map each-frame->json/tail stack))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Running server

--- a/rosette/lib/trace/tool.rkt
+++ b/rosette/lib/trace/tool.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
 (provide do-trace add-original-form!
-         symbolic-trace-tail?
          symbolic-trace-skip-assertion?
          symbolic-trace-skip-infeasible-solver?)
 
@@ -24,7 +23,6 @@
        ex)
      (thunk (begin0 (let () body ...) (restorer))))))
 
-(define symbolic-trace-tail? (make-parameter #f))
 (define symbolic-trace-skip-assertion? (make-parameter #f))
 (define symbolic-trace-skip-infeasible-solver? (make-parameter #f))
 

--- a/rosette/lib/trace/tool.rkt
+++ b/rosette/lib/trace/tool.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
-(provide do-trace record-apply! add-current-syntax! restore-current-syntax!
-         add-original-form!
+(provide do-trace add-original-form!
+         symbolic-trace-tail?
          symbolic-trace-skip-assertion?
          symbolic-trace-skip-infeasible-solver?)
 
@@ -24,6 +24,7 @@
        ex)
      (thunk (begin0 (let () body ...) (restorer))))))
 
+(define symbolic-trace-tail? (make-parameter #f))
 (define symbolic-trace-skip-assertion? (make-parameter #f))
 (define symbolic-trace-skip-infeasible-solver? (make-parameter #f))
 
@@ -33,13 +34,9 @@
 
 (define (do-trace proc #:entry-handler entry-handler #:post-proc post-proc)
   (set+restore
-   [current-syntax-list '()]
-   [current-activated-syntax #f]
    [current-original-map (make-hash)]
    [current-trace '()]
    [current-stats (make-hash stats-template)]
-   [current-stack '()]
-   [current-activated-stack #f]
    [current-entry-handler entry-handler #f]
    #:body
    (parameterize ([current-reporter reporter])
@@ -47,18 +44,6 @@
        (post-proc current-stats (reverse current-trace) current-original-map)))))
 
 ;; current-syntax --------------------------------------------------------------
-
-(define current-syntax-list '())
-(define current-activated-syntax #f)
-
-(define (add-current-syntax! stx)
-  (set! current-syntax-list (cons stx current-syntax-list)))
-
-(define (restore-current-syntax! [e #f])
-  (when (and e (not current-activated-syntax))
-    (set! current-activated-syntax (first current-syntax-list)))
-  (set! current-syntax-list (rest current-syntax-list))
-  e)
 
 (define current-original-map (make-hash))
 
@@ -89,38 +74,17 @@
                      (unsat? (query:solve (list the-pc))))
                 (collect-stats 'solver))))
      (unless skip?
-       (define entry (list e
-                           (or current-activated-syntax (first current-syntax-list))
-                           (or current-activated-stack current-stack)
-                           the-pc))
-       (current-entry-handler entry
-                              (λ (e) (set! current-trace (cons e current-trace)))
-                              current-original-map))
-     (set! current-activated-syntax #f)
-     (set! current-activated-stack #f)]
+       (define entry
+         (list e
+               (continuation-mark-set-first
+                (exn-continuation-marks e)
+                'symbolic-trace:stx-key)
+               (continuation-mark-set->list
+                (exn-continuation-marks e)
+                'symbolic-trace:stack-key)
+               the-pc))
+       (current-entry-handler
+        entry
+        (λ (e) (set! current-trace (cons e current-trace)))
+        current-original-map))]
     [_ (void)]))
-
-
-;; stack -----------------------------------------------------------------------
-
-(define current-stack '())
-(define current-activated-stack #f)
-
-(define (runner proc*)
-  (lambda (loc proc _in)
-    (set! current-stack (cons (cons proc loc) current-stack))
-    (call-with-exception-handler
-     (lambda (e)
-       (unless current-activated-stack
-         (set! current-activated-stack current-stack))
-       (set! current-stack (rest current-stack))
-       e)
-     (thunk (begin0 (proc*) (set! current-stack (rest current-stack)))))))
-
-(define record-apply!
-  (make-keyword-procedure
-   (lambda (kws kw-args loc proc . rest)
-     ((runner (thunk (keyword-apply proc kws kw-args rest)))
-      loc proc (append rest kw-args)))
-   (lambda (loc proc . rest)
-     ((runner (thunk (apply proc rest))) loc proc rest))))

--- a/test/trace/code/core-form.rkt
+++ b/test/trace/code/core-form.rkt
@@ -1,0 +1,11 @@
+#lang rosette
+
+(define-symbolic b boolean?)
+
+(define f
+  (case-lambda
+    [() (let-values ([(a b) 1])
+          1)]
+    [(a) (2)]))
+
+(when b (f))

--- a/test/trace/code/list-2.rkt
+++ b/test/trace/code/list-2.rkt
@@ -1,0 +1,9 @@
+#lang rosette
+
+(define (map f xs)
+  (cond
+    [(empty? xs) '()]
+    [else (cons (f (first xs)) (map f (rest xs)))]))
+
+(define-symbolic b boolean?)
+(map (thunk* (error 'bad)) (if b '() '(1)))

--- a/test/trace/code/non-tail.rkt
+++ b/test/trace/code/non-tail.rkt
@@ -1,0 +1,9 @@
+#lang rosette
+
+(define-symbolic b boolean?)
+(define (tri n)
+  (cond
+    [(zero? n) (1)]
+    [else (+ n (tri (sub1 n)))]))
+
+(when b (add1 (tri 10)))

--- a/test/trace/code/tail.rkt
+++ b/test/trace/code/tail.rkt
@@ -1,0 +1,9 @@
+#lang rosette
+
+(define-symbolic b boolean?)
+(define (tri n acc)
+  (cond
+    [(zero? n) (1)]
+    [else (tri (sub1 n) (+ acc n))]))
+
+(when b (add1 (tri 10 0)))

--- a/test/trace/output/regular/core-form.rkt.out
+++ b/test/trace/output/regular/core-form.rkt.out
@@ -1,0 +1,6 @@
+((#:stats #hash((assertion . 0) (solver . 0)))
+ (#:trace
+  (("result arity mismatch;\n expected number ...."
+    (let-values "core-form.rkt" 7 9)
+    ((f "core-form.rkt" 11 8))
+    b))))

--- a/test/trace/output/regular/ex-3.rkt.out
+++ b/test/trace/output/regular/ex-3.rkt.out
@@ -6,7 +6,9 @@
     (&& (&& ...) ...))
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
-    ((select "ex-3.rkt" 17 18) (select "ex-3.rkt" 21 28))
+    ((select "ex-3.rkt" 17 18)
+     (select "ex-3.rkt" 17 18)
+     (select "ex-3.rkt" 21 28))
     (&& (&& ...) ...))
    ("select: arity mismatch;\n the expected nu...."
     (#%app "ex-3.rkt" 16 24)
@@ -17,6 +19,7 @@
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
     ((select "ex-3.rkt" 17 18)
+     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 21 28))
     (&& (|| ...) ...))
@@ -32,6 +35,7 @@
     ((select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
+     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 21 28))
     (&& (|| ...) ...))
    ("select: arity mismatch;\n the expected nu...."
@@ -45,6 +49,7 @@
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
     ((select "ex-3.rkt" 17 18)
+     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)

--- a/test/trace/output/regular/ex-3.rkt.out
+++ b/test/trace/output/regular/ex-3.rkt.out
@@ -6,9 +6,7 @@
     (&& (&& ...) ...))
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
-    ((select "ex-3.rkt" 17 18)
-     (select "ex-3.rkt" 17 18)
-     (select "ex-3.rkt" 21 28))
+    ((select "ex-3.rkt" 17 18) (select "ex-3.rkt" 21 28))
     (&& (&& ...) ...))
    ("select: arity mismatch;\n the expected nu...."
     (#%app "ex-3.rkt" 16 24)
@@ -19,7 +17,6 @@
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
     ((select "ex-3.rkt" 17 18)
-     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 21 28))
     (&& (|| ...) ...))
@@ -35,7 +32,6 @@
     ((select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
-     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 21 28))
     (&& (|| ...) ...))
    ("select: arity mismatch;\n the expected nu...."
@@ -49,7 +45,6 @@
    ("assert: unexpected empty list\n"
     (assert "ex-3.rkt" 8 18)
     ((select "ex-3.rkt" 17 18)
-     (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)
      (select "ex-3.rkt" 17 18)

--- a/test/trace/output/regular/list-2.rkt.out
+++ b/test/trace/output/regular/list-2.rkt.out
@@ -1,0 +1,8 @@
+((#:stats #hash((assertion . 0) (solver . 0)))
+ (#:trace
+  (("error: bad\n"
+    (#%app "list-2.rkt" 9 13)
+    ((error "list-2.rkt" 9 13)
+     (...race/code/list-2.rkt:9:5 "list-2.rkt" 6 16)
+     (map "list-2.rkt" 9 0))
+    (! b)))))

--- a/test/trace/output/regular/list.rkt.out
+++ b/test/trace/output/regular/list.rkt.out
@@ -1,6 +1,3 @@
 ((#:stats #hash((assertion . 0) (solver . 0)))
  (#:trace
-  (("error: bad\n"
-    (#%app "list.rkt" 4 13)
-    ((error "list.rkt" 4 13) (@map "list.rkt" 4 0))
-    (! b)))))
+  (("error: bad\n" (#%app "list.rkt" 4 13) ((error "list.rkt" 4 13)) (! b)))))

--- a/test/trace/output/regular/non-tail.rkt.out
+++ b/test/trace/output/regular/non-tail.rkt.out
@@ -1,0 +1,17 @@
+((#:stats #hash((assertion . 0) (solver . 0)))
+ (#:trace
+  (("application: not a procedure;\n expected ...."
+    (#%app "non-tail.rkt" 6 15)
+    ((1 "non-tail.rkt" 6 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 7 15)
+     (tri "non-tail.rkt" 9 14))
+    b))))

--- a/test/trace/output/regular/tail.rkt.out
+++ b/test/trace/output/regular/tail.rkt.out
@@ -1,0 +1,6 @@
+((#:stats #hash((assertion . 0) (solver . 0)))
+ (#:trace
+  (("application: not a procedure;\n expected ...."
+    (#%app "tail.rkt" 6 15)
+    ((1 "tail.rkt" 6 15) (tri "tail.rkt" 9 14))
+    b))))

--- a/test/trace/perf-runner.rkt
+++ b/test/trace/perf-runner.rkt
@@ -1,0 +1,41 @@
+#lang racket
+
+(require rosette/lib/trace/compile
+         rosette/lib/trace/tool
+         (only-in rosette clear-state!)
+         racket/runtime-path
+         "../config.rkt")
+
+(define ns (current-namespace))
+(define ITERATIONS 10)
+
+(define (run-trace-test fname)
+  (clear-state!)
+  (parameterize ([current-compile symbolic-trace-compile-handler]
+                 [current-namespace (make-base-namespace)]
+                 [error-print-width default-error-print-width])
+    (namespace-attach-module ns 'rosette)
+    (with-handlers ([exn:fail? (λ (e)
+                                 ((error-display-handler)
+                                  (if (exn? e)
+                                      (exn-message e)
+                                      (~a e))
+                                  e))])
+      (do-trace
+       (thunk
+        (dynamic-require `(file ,(path->string (build-path here-dir "stress" fname))) #f))
+       #:entry-handler (λ (entry add-trace! _current-original-map)
+                         (add-trace! entry))
+       #:post-proc void))))
+
+(define-runtime-path here-dir ".")
+
+(define (run-mode tests)
+  (for ([filename (in-list tests)])
+    (define test-file (string->path filename))
+    (match-define-values (_ cpu _ _)
+      (time-apply (thunk (for ([_i (in-range ITERATIONS)])
+                           (run-trace-test test-file))) '()))
+    (printf "Time: ~a\n" (~r (/ cpu ITERATIONS) #:precision 2))))
+
+(run-mode '("non-tail.rkt" "tail.rkt"))

--- a/test/trace/stress/non-tail.rkt
+++ b/test/trace/stress/non-tail.rkt
@@ -1,0 +1,9 @@
+#lang rosette
+
+(define-symbolic b boolean?)
+(define (tri n)
+  (cond
+    [(zero? n) (1)]
+    [else (+ n (tri (sub1 n)))]))
+
+(when b (add1 (tri 500000)))

--- a/test/trace/stress/tail.rkt
+++ b/test/trace/stress/tail.rkt
@@ -1,0 +1,9 @@
+#lang rosette
+
+(define-symbolic b boolean?)
+(define (tri n acc)
+  (cond
+    [(zero? n) (1)]
+    [else (tri (sub1 n) (+ acc n))]))
+
+(when b (add1 (tri 500000 0)))

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -51,13 +51,8 @@
         (substring-top (exn->string ex) 40)))
     (define activated-syntax-out (format-activated-syntax activated-syntax))
     (define activated-stack-out
-      (cond
-        [(symbolic-trace-tail?)
-         (append (format-first-stack-elem/tail activated-stack)
-                 (filter-map format-each-stack-elem/tail activated-stack))]
-        [else
-         (append (format-first-stack-elem/tail activated-stack)
-                 (filter-map format-each-stack-elem/tail activated-stack))]))
+      (append (format-first-stack-elem/tail activated-stack)
+              (filter-map format-each-stack-elem/tail activated-stack)))
     (list ex-out activated-syntax-out activated-stack-out pc))
   (serialize
    `((#:stats ,stats)

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -81,6 +81,11 @@
        (printf "Wrote new output for `~a`: ~v\n" fname output)]))
 
   (define (exn-handler e)
+    ((error-display-handler)
+     (if (exn? e)
+         (exn-message e)
+         (~a e))
+     e)
     (perform-test
      `((#:error ,(parameterize ([error-print-context-length 0]) (exn->string e))))))
 

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -33,11 +33,13 @@
     (list (or (object-name proc) proc) (path->name path) line col))
   (define (format-each-stack-elem/tail elem)
     (match elem
+      [#f #f]
       [(list 'uncertified _ _) #f]
       [(list _ elem _) (apply format-stack-elem/tail elem)]))
   (define (format-first-stack-elem/tail xs)
     (match xs
       ['() '()]
+      [(cons #f xs) (format-first-stack-elem/tail xs)]
       [(cons (list _ _ elem) _) (list (apply format-stack-elem/tail elem))]))
 
 
@@ -54,7 +56,6 @@
          (append (format-first-stack-elem/tail activated-stack)
                  (filter-map format-each-stack-elem/tail activated-stack))]
         [else
-         ;; TODO
          (append (format-first-stack-elem/tail activated-stack)
                  (filter-map format-each-stack-elem/tail activated-stack))]))
     (list ex-out activated-syntax-out activated-stack-out pc))
@@ -134,12 +135,10 @@
                         "forall.rkt"
                         "infeasible-solver.rkt"
                         "list.rkt"
+                        "list-2.rkt"
                         "no-error.rkt"
                         "test-stack.rkt"
                         "toplevel.rkt"))
-
-(define tail-tests '("tail.rkt"
-                     "non-tail.rkt"))
 
 (define solver-tests '("assertion.rkt"
                        "if.rkt"
@@ -162,8 +161,6 @@
   (run-mode solver-tests "solver" `([,symbolic-trace-skip-infeasible-solver? #t])))
 (define assertion-suites
   (run-mode assertion-tests "assertion" `([,symbolic-trace-skip-assertion? #t])))
-(define tail-suites
-  (run-mode tail-tests "tail" `([,symbolic-trace-tail? #t])))
 (define all-suites
   (run-mode all-tests "all" `([,symbolic-trace-skip-infeasible-solver? #t]
                               [,symbolic-trace-skip-assertion? #t])))
@@ -172,7 +169,6 @@
   (require rackunit/text-ui)
 
   (for-each run-tests regular-suites)
-  (for-each run-tests tail-suites)
   (for-each run-tests solver-suites)
   (for-each run-tests assertion-suites)
   (for-each run-tests all-suites))

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -125,6 +125,7 @@
                         "ex-3.rkt"
                         "tail.rkt"
                         "non-tail.rkt"
+                        "core-form.rkt"
                         "assertion.rkt"
                         "if.rkt"
                         "infeasible.rkt"

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -40,7 +40,7 @@
     (match xs
       ['() '()]
       [(cons #f xs) (format-first-stack-elem/tail xs)]
-      [(cons (list 'certified a b) _) #:when (equal? a b) '()]
+      [(cons (list 'certified a b) _) #:when (eq? a b) '()]
       [(cons (list _ _ elem) _) (list (apply format-stack-elem/tail elem))]))
 
 

--- a/test/trace/test.rkt
+++ b/test/trace/test.rkt
@@ -40,6 +40,7 @@
     (match xs
       ['() '()]
       [(cons #f xs) (format-first-stack-elem/tail xs)]
+      [(cons (list 'certified a b) _) #:when (equal? a b) '()]
       [(cons (list _ _ elem) _) (list (apply format-stack-elem/tail elem))]))
 
 


### PR DESCRIPTION
This PR implements a new strategy to instrument code via the `with-continuation-mark` feature. Note that using `w-c-m` naively, like how the `errortrace` library does, gives a suboptimal stack trace, so we use a different algorithm that gives a better result (see details below).

The new strategy is more efficient than the current one. Here's a benchmark result, obtained from running `test/trace/perf-runner.rkt`.

```
Current strategy
----------------
test/trace/stress/non-tail.rkt: 1628.1 ms
test/trace/stress/tail.rkt: 1409.2 ms

New strategy
------------
test/trace/stress/non-tail.rkt: 1018 ms
test/trace/stress/tail.rkt: 401.7 ms
```

The new strategy preserves proper tail recursion (as does `errortrace`): space complexity does not change after instrumentation. This seems to have a side effect of speeding up programs with tail recursion significantly, as shown in the above benchmark (`tail.rkt`). However, this property is a double-edged sword because it means some logical stack frames must be elided. In practice, the elision doesn't seem to affect debuggability much, as most other frames can still provide useful information, and it is very rare for a symbolic program to have tail recursion due to path merging, so everything seems to work out just fine.

## Instrumentation 

See the proposal to improve Racket's `errortrace` at https://www.mail-archive.com/racket-users@googlegroups.com/msg44786.html for the background and see Matthew's suggestion for an efficient implementation strategy that I ended up basing my algorithm on.

It turns out that the proposal doesn't quite work as I expected. Consider the program:

```
(define (fact n)
  (if (zero? n) (1) (* n (fact (sub1 n)))))
(add1 (fact 5))
```

By using the mentioned algorithm, the `add1` frame will be kept, even though we have not really called `add1` yet when the error occurs.

To filter out the `add1` frame, we refine the algorithm by assigning a flag saying that a mark is "uncertified" every time we attach a new one. Therefore, both `add1` and `fact` frames will be uncertified initially. Then, in every function body, we certify its frame. This causes `fact` to be certified while leaving `add1` uncertified. By throwing away uncertified frames when an error occurs, we obtain the stack trace as desired.

The actual implementation is slightly more complicated because we need to work with the expanded code. Not all function calls are user-written, so we should not add new information for these calls (e.g., `branch-and-merge` should not appear in the stack trace).

## Limitation

The above algorithm relies on a function to certify its frame. This means that if the function is not instrumented (especially for higher-order functions that are defined in stdlib), the uncertified frame will be missing. This could be seen as either a bug or a feature. Arguably, these missing frames are not useful on their own, but their absence might be surprising.

## Tests

Interestingly, from all 31 existing tests, only one outputs differently after switching to the new strategy. This suggests that the new strategy is highly compatible with the current one. For the (only one) test that failed, it is due to the limitation described above (`list.rkt` misses a frame due to the higher-order, built-in function `map`). 