### PR TITLE
bmv: handle #%variable-reference

### DIFF
--- a/rosette/base/form/module.rkt
+++ b/rosette/base/form/module.rkt
@@ -160,7 +160,9 @@
             [vs (syntax->list #'(var ...))])
         (cond [(any-mutated? vs)
                (let ([locs (generate-temporaries vs)])
-                 (for ([v (in-list vs)] [loc (in-list locs)])
+                 (for ([v (in-list vs)]
+                       [loc (in-list locs)]
+                       #:when (mutated? v))
                    (dict-set! varref-tbl v loc))
                  (quasisyntax* stx
                    (begin


### PR DESCRIPTION
Because bmv transforms `define-values v` to `define-syntax v`,
a varref on `v` would fail, as `v` now doesn't have a location.

The fix is to adjust the shadow variables to have the same scope as the
original `v`, and perform varref on the shadow variables instead.
Note that while the names of shadow variables might collide with existing
variables, `generate-temporaries` makes sure that the scope of the
newly generated symbols won't collide, so this should cause no problem.