### PR TITLE
Support CVC4 1.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on: [push, pull_request]
 
 env:
-  CVC4_URL: "http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/cvc4-1.5-x86_64-linux-opt"
+  CVC4_URL: "http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/cvc4-1.8-x86_64-linux-opt"
   BOOLECTOR_URL: "https://github.com/Boolector/boolector/archive/3.2.1.tar.gz"
 
 jobs:

--- a/rosette/solver/smt/cvc4.rkt
+++ b/rosette/solver/smt/cvc4.rkt
@@ -8,7 +8,7 @@
 (provide (rename-out [make-cvc4 cvc4]) cvc4? cvc4-available?)
 
 (define-runtime-path cvc4-path (build-path ".." ".." ".." "bin" "cvc4"))
-(define cvc4-opts '("-L" "smt2" "-q" "-m" "-i" "--continued-execution" "--bv-div-zero-const"))
+(define cvc4-opts '("-L" "smt2" "-q" "-m" "-i" "--bv-print-consts-as-indexed-symbols" "--bv-div-zero-const"))
 
 (define (cvc4-available?)
   (not (false? (base/find-solver "cvc4" cvc4-path #f))))


### PR DESCRIPTION
The `--continued-execution` option was removed (see https://github.com/CVC4/CVC4/issues/792), and the `--bv-print-consts-as-indexed-symbols` option is necessary in version 1.8. 