### PR TITLE
Add 'concrete?' function

### DIFF
--- a/rosette/base/base.rkt
+++ b/rosette/base/base.rkt
@@ -45,7 +45,7 @@
      ; core/equality.rkt
      @eq? @equal?
      ; core/reflect.rkt
-     symbolics type? solvable? @any/c type-of type-cast for/all for*/all
+     symbolics concrete? type? solvable? @any/c type-of type-cast for/all for*/all
      term? constant? expression? 
      term expression constant term-type
      term=? term->datum clear-terms! term-cache


### PR DESCRIPTION
I think this is a useful function for symbolic reflection. It gives the same results as `(empty? (symbolics _))`, but it's more efficient because it returns as soon as it finds an expression or union. The pattern arose frequently enough in my code that this was a useful optimization.

This is a draft PR; if you think this would be a useful addition, I can add tests/docs.