### PR TITLE
remove dependency on now-nonexistent file

### DIFF
--- a/rosette/guide/scribble/reflection/value-reflection.scrbl
+++ b/rosette/guide/scribble/reflection/value-reflection.scrbl
@@ -241,8 +241,8 @@ as well as for tuning the performance of symbolic
 evaluation.
 
 
-@declare-exporting[rosette/base/core/forall rosette/lib/lift
-                   #:use-sources (rosette/base/core/forall rosette/lib/lift)]
+@declare-exporting[rosette/base/core/forall
+                   #:use-sources (rosette/base/core/forall)]
 
 @defform[(for/all ([id val-expr maybe-exhaustive]) body ...+)
          #:grammar [(maybe-exhaustive (code:line) #:exhaustive)]]{

--- a/sdsl/fsm/lib.rkt
+++ b/sdsl/fsm/lib.rkt
@@ -1,7 +1,6 @@
 #lang rosette
 
 (require 
- rosette/lib/lift 
  (prefix-in racket/ (only-in racket string-append symbol->string regexp-match?)))
 
 (provide (all-defined-out))


### PR DESCRIPTION
see commit c76b803836f89d3bb4 which removes
the file and the use of define/lift

This change appears to allow this file to compile.