### PR TITLE
Workaround spurious CAS failures

### DIFF
--- a/rosette/lib/util/streaming-server.rkt
+++ b/rosette/lib/util/streaming-server.rkt
@@ -14,37 +14,38 @@
   ; the procedure for handling connections
   (define (ws-connection conn _state)
     ; only one client may connect
-    (cond
-      [(box-cas! connected? #f #t)  ; we won the race to connect
-       ; tell the main thread we're connected
-       (channel-put channel 'connected)
-       ; loop until we're done
-       (let loop ()
-         (define sync-result (sync/timeout/enable-break interval channel))
-         (define messages (get-message))
+    (let loop ([tries 128])
+      (cond
+        [(zero? tries) (channel-put channel "another client is already connected")
+                       (ws-close! conn)]
+        [(box-cas! connected? #f #t)  ; we won the race to connect
+         ; tell the main thread we're connected
+         (channel-put channel 'connected)
+         ; loop until we're done
+         (let loop ()
+           (define sync-result (sync/timeout/enable-break interval channel))
+           (define messages (get-message))
 
-         ; send the messages; bail out if it fails
-         (define continue? (not (eq? sync-result 'finish)))
-         (with-handlers ([exn:fail? (lambda (e)
-                                      (eprintf "~e\n" e)
-                                      (set! continue? #f))])
-           (ws-send! conn (jsexpr->bytes messages)))
-         (if continue?
-             (loop)
-             (begin
-               (with-handlers ([exn:fail? void])  ; the connection might be dead, but we don't care
-                 (ws-send! conn (jsexpr->bytes (list (get-finish-message))))
-                 (ws-close! conn))
-               ; if we weren't told to shut down, we need to wait until we are.
-               (cond
-                 [on-shutdown (on-shutdown)]
-                 [else
-                  (unless (eq? sync-result 'finish)
-                    (channel-get channel))
-                  (channel-put channel 'finish)]))))]
-      [else
-       (channel-put channel "another client is already connected")
-       (ws-close! conn)]))
+           ; send the messages; bail out if it fails
+           (define continue? (not (eq? sync-result 'finish)))
+           (with-handlers ([exn:fail? (lambda (e)
+                                        (eprintf "~e\n" e)
+                                        (set! continue? #f))])
+             (ws-send! conn (jsexpr->bytes messages)))
+           (if continue?
+               (loop)
+               (begin
+                 (with-handlers ([exn:fail? void])  ; the connection might be dead, but we don't care
+                   (ws-send! conn (jsexpr->bytes (list (get-finish-message))))
+                   (ws-close! conn))
+                 ; if we weren't told to shut down, we need to wait until we are.
+                 (cond
+                   [on-shutdown (on-shutdown)]
+                   [else
+                    (unless (eq? sync-result 'finish)
+                      (channel-get channel))
+                    (channel-put channel 'finish)]))))]
+        [else (loop (sub1 tries))])))
 
   ; start the server
   (define conf-channel (make-async-channel))


### PR DESCRIPTION
Some processors, such as ARM, can't perform the CAS (compare-and-swap)
operation accurately. So we simply retry on failure for several times.

Fixes #197 