### PR TITLE
Fix model parsing for Boolector 3.2.2

### DIFF
--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -122,9 +122,8 @@
          [(== 'sat)
           (server-write server (get-model))
           (match (server-read server (read))
-            [(list (== 'model) def ...)
-             (for/hash ([d def] #:when (and (pair? d) (equal? (car d) 'define-fun)))
-               (values (cadr d) d))]
+            [(list (== 'model) ... (and def (list (== 'define-fun) _ ...)) ...)
+             (for/hash ([d def]) (values (cadr d) d))]
             [other (error 'read-solution "expected model, given ~a" other)])]
          [(== 'unsat) 'unsat]
          [(== 'unknown) 'unknown]


### PR DESCRIPTION
The latest Boolector release [changed][] the format of SMT models to conform
to the SMT-LIB spec by not including the `model` symbol, which our
parser was expecting (mostly because that's what Z3 does). It's not hard
to support both versions, so let's do that.

Tested by running the Rosette tests with both Boolector v3.2.1 and v3.2.2.

[changed]: https://github.com/Boolector/boolector/commit/5c862bcdbc1ceb95984c0dc5d4dfbd05a1ed0639
