### PR TITLE
Adding clause for boolector solver without model string

### DIFF
--- a/rosette/solver/smt/boolector.rkt
+++ b/rosette/solver/smt/boolector.rkt
@@ -124,6 +124,8 @@
           (match (server-read server (read))
             [(list (== 'model) ... (and def (list (== 'define-fun) _ ...)) ...)
              (for/hash ([d def]) (values (cadr d) d))]
+            [(list  (and def (list (== 'define-fun) _ ...)) ...)
+             (for/hash ([d def]) (values (cadr d) d))]
             [other (error 'read-solution "expected model, given ~a" other)])]
          [(== 'unsat) 'unsat]
          [(== 'unknown) 'unknown]


### PR DESCRIPTION
I was using the boolector solver for our research and found it crashing with an error message saying something along the lines of `expected model, given (define-func ...)`. The Z3 solver outputs the string `model` when a solution exists for the solver, but the boolector solver wasn't in this case. After the adding the match clause without the `(== 'model)` entry the boolector solver worked as expected. I wanted to point out this issue upstream.