### PR TITLE
Add Docker image and continuous deployment for it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Docker
+
+on:
+  push:
+    tags:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          submodules: recursive
+
+      - name: Configure Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/emina/rosette
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Authenticate to Package Registry
+        uses: docker/login-action@v1
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and Publish Sekkou Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:
@@ -14,15 +14,12 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.BOT_PAT }}
-          submodules: recursive
 
       - name: Configure Docker Metadata
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/emina/rosette
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -40,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build and Publish Sekkou Image
+      - name: Build and Publish Rosette Image
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,19 @@ FROM alpine:3.15
 ARG RACKET_VERSION=8.4
 ARG RACKET_VARIANT=cs
 
-## Install Racket. This goes by downloading the installer, running it with the
-## right parameters, then removing it. [gcompat] is needed for Racket.
+## Install Racket. We first install system dependencies: [gcompat] is needed for
+## Racket and [ncurses] is needed for the [xrepl] and [expeditor] packages,
+## providing the REPL. We then download the installer, run it with the right
+## parameters, then remove it. After that, all that remains is to set-up the
+## Racket packages and install [expeditor]. See later for a description of the
+## arguments to [raco pkg install].
 ##
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache gcompat ncurses
 RUN wget "https://download.racket-lang.org/installers/${RACKET_VERSION}/racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh"
 RUN echo 'yes\n1\n' | sh racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh --create-dir --unix-style --dest /usr/
 RUN rm racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh
 RUN raco setup --no-docs
+RUN raco pkg install -i --batch --auto --no-docs expeditor-lib
 
 ## =================== [ Install Rosette's Dependencies ] =================== ##
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# FROM racket/racket:8.3-full
-
 FROM alpine:3.15
 
 ## ==========================  [ Install Racket ] =========================== ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,4 @@ WORKDIR /rosette
 ## Rosette files are simply Racket files using the Rosette library: the default
 ## entry point of this image is therefore the Racket executable.
 ##
-ENTRYPOINT ["/usr/bin/racket"]
+ENTRYPOINT ["/usr/bin/racket", "-I", "rosette"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,94 @@
+# FROM racket/racket:8.3-full
+
+FROM alpine:3.15
+
+## ==========================  [ Install Racket ] =========================== ##
+
+## Define default Racket version and variant. The Racket version is of the form
+## <major>.<minor>. The variant can be "cs" (Chez Scheme), "bc" (Before Chez) or
+## "natipkg" (where external libraries are included in the Racket packages).
+##
+ARG RACKET_VERSION=8.4
+ARG RACKET_VARIANT=cs
+
+## Install Racket. This goes by downloading the installer, running it with the
+## right parameters, then removing it. [gcompat] is needed for Racket.
+##
+RUN apk add --no-cache gcompat
+RUN wget "https://download.racket-lang.org/installers/${RACKET_VERSION}/racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh"
+RUN echo 'yes\n1\n' | sh racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh --create-dir --unix-style --dest /usr/
+RUN rm racket-minimal-${RACKET_VERSION}-x86_64-linux-${RACKET_VARIANT}.sh
+RUN raco setup --no-docs
+
+## =================== [ Install Rosette's Dependencies ] =================== ##
+
+## Work on Rosette's installation within /usr/local. This directory will be
+## cleaned up later on so it could be anything.
+##
+WORKDIR /usr/local/rosette
+
+## Get all the info.rkt files. Trying to install Rosette based only on these
+## files would fail, but we can use them to only install dependencies.
+##
+COPY info.rkt         .
+COPY rosette/info.rkt rosette/
+
+## Install only Rosette's dependencies. We have to install the external
+## dependencies [libstdc++] and [libgcc] because Z3 needs them at runtime. As
+## for the Racket dependencies only, we achieve that in three steps:
+##
+##   1. We use [raco pkg install --no-setup] to download and register Rosette
+##      and all its dependencies without setting them up, that is without
+##      compiling them. At this point, the system is in an inconsistent state,
+##      where packages are registered but not actually present. The other flags
+##      are the following:
+##
+##        -i         install packages for all users
+##        --batch    disable interactive mode and suppress prompts
+##        --auto     download missing packages automatically
+##
+##   2. We use [raco pkg remove --no-setup] to unregister Rosette. This keeps
+##      the dependencies as registered. The system is still in an inconsistent
+##      state. See above for the flags.
+##
+##   3. We use [raco setup] to set up all the registered package. This brings
+##      the system back in a consistent state. Since Rosette's dependencies were
+##      registered but not Rosette itself, this achieves our goal. The flags are
+##      the following:
+##
+##        --fail-fast    fail on the first error encountered
+##        --no-docs      do not compile the documentations
+##
+RUN apk add --no-cache libstdc++ libgcc
+RUN raco pkg install -i --batch --auto --no-setup ../rosette
+RUN raco pkg remove  -i                --no-setup    rosette
+RUN raco setup       --fail-fast --no-docs
+
+## ========================== [ Install Rosette ] =========================== ##
+
+## Get all of Rosette; build and install it. The dependencies should all be
+## installed, so we can remove the --auto flag which will lead us to failure if
+## a dependency cannot be found. The additional flags are the following:
+##
+##   --copy    copy content to install path (instead of linking)
+##
+COPY . .
+RUN raco pkg install -i --batch --copy --no-docs ./rosette
+RUN rm -R /usr/local/rosette
+
+## ===================== [ Prepare Clean Entry Point ] ====================== ##
+
+## For further use of the image, we can start with user `rosette`, group
+## `rosette` in `/rosette` by default.
+##
+RUN addgroup rosette
+RUN adduser --system --shell /bin/false --disabled-password \
+    --home /rosette --ingroup rosette rosette
+RUN chown -R rosette:rosette /rosette
+USER rosette
+WORKDIR /rosette
+
+## Rosette files are simply Racket files using the Rosette library: the default
+## entry point of this image is therefore the Racket executable.
+##
+ENTRYPOINT ["/usr/bin/racket"]


### PR DESCRIPTION
closes #217 

This PR defines a Docker image with just enough to run Rosette with Z3. It also adds a GitHub workflow to automatically build the Docker image on pushes to `main` and pull requests and to automatically publish the Docker image to [GitHub Packages](https://github.com/features/packages). 

In general, I believe the Docker image is quite well documented. A lot of things have also been discussed in #217. For the base image, the choice was to work from scratch, building on top of Alpine and installing Racket by hand. It should be fairly easy to update the Dockerfile for another version of Racket.

The Docker image has a bit of a complicated structure:
- It first imports only the `info.rkt` files and uses them to install all of Rosette's dependencies. (The trick that I use for that seems fairly complicated: if you have a better solution, I'd love to hear it!)
- Once this is done, it imports all the files of the current directory and builds and installs Rosette.

The reason for this structure is to make the best use of Docker's cache: as long as `info.rkt` do not change, rebuilding the Docker image is only a matter of rebuilding Rosette. (On my laptop, around 45 seconds.) This can be practical when developing locally with Rosette. It also speeds up the continuous deployment when there has been a build less than seven (ten?) days before.

The Docker image presents a user `rosette` in group `rosette`, working in `/rosette` by default. It is fairly easy to make Rosette work on external files by use of mounting, eg. with:
```
time docker run --mount type=bind,source="$PWD",target=/src ghcr.io/emina/rosette /src/test.rkt
```
while having an appropriate `test.rkt` file in the current directory. You may actually try the above command with `ghcr.io/niols/rosette:docker-demo` which [I published](https://github.com/Niols/rosette/pkgs/container/rosette) for demonstration purposes and will remove after this PR is done. This will require you to login to GHCR as shown [here](https://github.com/features/packages), you might want a PAT with no specific rights for that.

The Docker image does not contain documentation of Rosette or its dependencies, so as to reduce its size. If you knew how I could also remove build dependencies, that would be great. The Docker image is also built on top of Racket minimal and does not include what is necessary to run DrRacket. I didn't think it was the goal but if I am mistaken please let me know and I will fix it.

I took the liberty to add a configuration for Dependabot, that creates pull requests whenever GitHub Action dependencies can be updated (eg. `action/checkout`).

~In order to work properly, the GitHub Action workflow needs to be able to push to GitHub Packages. This can be done in the global Settings > Developer Settings > Personal access tokens, by creating a new token that has the `write:packages` rights (which will imply the `repo` rights). This token then has to be provided as a secret in the repository's Settings > Secrets > Actions under the name `BOT_PAT`. I can rename this in something else if you think that is more appropriate, eg. `GHCR_PAT`?~

We could easily adapt this PR to publish to Docker Hub instead, which would avoid requiring people to login to GitHub Packages and have the image be named `emina/rosette` instead of `ghcr.io/emina/rosette`.

I probably forgot a lot of things, so don't hesitate to shoot if you have questions!