### PR TITLE
The result of a get-model command should be compatible with SMT-LIB standard

### DIFF
--- a/rosette/solver/smt/base-solver.rkt
+++ b/rosette/solver/smt/base-solver.rkt
@@ -142,6 +142,11 @@
             [(list (== 'model) def ...)
              (for/hash ([d def] #:when (and (pair? d) (equal? (car d) 'define-fun)))
                (values (cadr d) d))]
+            ;; the result of a get-model command compatible with SMT-LIB standard
+            ;; https://groups.google.com/g/smt-lib/c/5xpcIxdQ8-A/m/X4uQ7dIgAwAJ
+            [(list def ...)
+             (for/hash ([d def] #:when (and (pair? d) (equal? (car d) 'define-fun)))
+               (values (cadr d) d))]
             [other (error 'read-solution "expected model, given ~a" other)]))]
        [(== 'unsat)
         (if unsat-core?


### PR DESCRIPTION
According to SMT-LIB standard, the answer to `(get-model)` should just be a list of (define-fun...) commands, e.g.
```
(get-model)
((define-fun x () Int 0) 
 (define-fun y () Int 1))
```

However, currently many solvers (e.g. z3-4.8.7) adds additional `model` keyword in the answer:
```
(get-model)
(model 
 (define-fun x () Int 0)
 (define-fun y () Int 1))
```

This issue has been fixed in the latest version of z3 (e.g. z3-4.8.12). but rosette code has not be updated (so cannot run normally in z3-4.8.12).

This patch supports both two formats.

More details see https://groups.google.com/g/smt-lib/c/5xpcIxdQ8-A/m/X4uQ7dIgAwAJ