### PR TITLE
improve error location

### DIFF
--- a/rosette/lib/destruct.rkt
+++ b/rosette/lib/destruct.rkt
@@ -48,10 +48,11 @@
 
 (define-simple-macro (destruct val [pat:clause-pattern e:expr ...+] ...)
   #:do [(for-each check-duplicate-identifier! (attribute pat.id-set))]
+  #:with match-expr (syntax/loc this-syntax (match var [pat (begin e ...)] ...))
   #:with result
   (syntax/loc this-syntax
     (for/all ([var val]);(guarded-values val)])
-      (match var [pat (begin e ...)] ...)))
+      match-expr))
   result)
 
 (define-simple-macro (destruct* (val ...) [(pat:clause-pattern ...) e:expr ...+] ...)


### PR DESCRIPTION
```
(struct a ())
(struct b ())
(match (a)
  [(b) 1])
```

blames `(match ...)` in Racket. However, the morally equivalent expression in the `destruct` library does not correctly blame the faulty expression:

```
(require rosette/lib/destruct)
(struct a ())
(struct b ())
(destruct (a) ;=> blame an internal implementation of destruct
  [(b) 1])
```

This PR fixes the issue.