### PR TITLE
Disallow define-symbolic with different types

### DIFF
--- a/test/base/term.rkt
+++ b/test/base/term.rkt
@@ -14,6 +14,10 @@
 (define-symbolic b @boolean?)
 (define-symbolic c @boolean?)
 
+(define (f type)
+  (define-symbolic x type)
+  x)
+
 (define (check-ordered v1 v2)
   (check-true (and (or (term<? v1 v2) (term<? v2 v1)) 
                    (not (and (term<? v1 v2) (term<? v2 v1))))))
@@ -49,7 +53,10 @@
    (check-cached @/ x y)
    (check-cached @remainder x y)
    (check-cached @= x y)
-   (check-cached @< x y)))
+   (check-cached @< x y)
+
+   (f @integer?)
+   (check-exn #px"type should remain unchanged" (lambda () (f @boolean?)))))
 
 (module+ test
   (time (run-tests value-tests)))


### PR DESCRIPTION
Programs like:

```
(define (f type)
  (define-symbolic x type)
  x)

(+ 1 (f integer?))
(+ 2 (f boolean?))
```

should not work. The second call in particular should result in an
error, rather than using the cached term (which is an integer).

This PR makes the above program invalid. The SDSL benchmarks show that
the performance was not affected by the change.

The issue was originally discovered by @gussmith23.