### PR TITLE
Make evaluate preserve vector immutability

### DIFF
--- a/rosette/query/eval.rkt
+++ b/rosette/query/eval.rkt
@@ -47,7 +47,10 @@
                [(cons x y)               
                 (cons (eval-rec x sol cache) (eval-rec y sol cache))]
                [(? vector?)              
-                (for/vector #:length (vector-length expr) ([e expr]) (eval-rec e sol cache))]
+                (let ([v (for/vector #:length (vector-length expr) ([e expr]) (eval-rec e sol cache))])
+                  (if (immutable? expr)
+                      (vector->immutable-vector v)
+                      v))]
                [(? box?)
                 ((if (immutable? expr) box-immutable box) (eval-rec (unbox expr) sol cache))]
                [(? typed?)              


### PR DESCRIPTION
Prior to this patch, the following returned an immutable vector:

```racket
(define empty-model (solve (void)))
(evaluate (vector-immutable 1) empty-model)
```

However, the following returned a _mutable_ vector, even though `evaluate` is given an immutable vector (containing no symbolics):

```racket
(define-symbolic* b boolean?)
(define model (solve (assert b)))
(evaluate (vector-immutable 1) model)
```

With this patch, both examples above return an immutable vector.
