### PR TITLE
Fix the help description

### DIFF
--- a/rosette/lib/profile/raco.rkt
+++ b/rosette/lib/profile/raco.rkt
@@ -40,7 +40,7 @@
                  "Only install the compile handler; do not run the profiler"
                  (run-profiler? #f)]
                 [("-m" "--module") name
-                 "Run submodule <name> (defaults to 'main)"
+                 "Run submodule <name> (defaults to 'main')"
                  (module-name (string->symbol name))]
                 [("-r" "--racket")
                  "Instrument code in any language, not just `#lang rosette`"

--- a/rosette/lib/trace/raco.rkt
+++ b/rosette/lib/trace/raco.rkt
@@ -29,7 +29,7 @@
 
    ;; SymPro options
    [("-m" "--module") name
-                      "Run submodule <name> (defaults to 'main)"
+                      "Run submodule <name> (defaults to 'main')"
                       (module-name (string->symbol name))]
    [("-r" "--racket")
     "Instrument code in any language, not just `#lang rosette`"


### PR DESCRIPTION
The command-line option is a simple string "main", not a Racket symbol