### PR TITLE
Fix unintentional value retain

### DIFF
--- a/rosette/base/core/term.rkt
+++ b/rosette/base/core/term.rkt
@@ -46,7 +46,7 @@
               (set-add! evicted t))
             (loop))))))
 
-; Sets the current term cache to a garbage-collected (ephemeron) hash.
+; Sets the current term cache to a garbage-collected (weak) hash.
 ; The setting preserves all reachable terms from (current-terms).
 (define (gc-terms!)
   (unless (hash-weak? (current-terms)) ; Already a weak hash.


### PR DESCRIPTION
To quote to the documentation of parameters
(https://docs.racket-lang.org/reference/parameters.html),

> as far as the memory manager is concerned,
> the value originally associated with a parameter through parameterize
> remains reachable as long the continuation is reachable,
> even if the parameter is mutated.

The parameter current-terms is initialized and/or parameterized to a strong hash, making it not possible to GC the hash. This PR fixes the issue by initializing and/or parameterizing to #f first, and then mutates the parameter to a desired value later.

Fixes #247