### PR TITLE
avoid quadratic time processing in solver-(assert,min/maximize)

### DIFF
--- a/rosette/solver/smt/z3.rkt
+++ b/rosette/solver/smt/z3.rkt
@@ -52,10 +52,10 @@
      (base/solver-assert self bools))
 
    (define (solver-minimize self nums)
-     (base/set-solver-mins! self (append (base/solver-mins self) (numeric-terms nums 'solver-minimize))))
+     (base/set-solver-mins! self (append (reverse (numeric-terms nums 'solver-minimize)) (base/solver-mins self))))
    
    (define (solver-maximize self nums)
-     (base/set-solver-maxs! self (append (base/solver-maxs self) (numeric-terms nums 'solver-maximize))))
+     (base/set-solver-maxs! self (append (reverse (numeric-terms nums 'solver-maximize)) (base/solver-maxs self))))
    
    (define (solver-clear self) 
      (base/solver-clear-stacks! self)


### PR DESCRIPTION
The time complexity of n calls to solver-assert / solver-minimize / solver-maximize is currently O(n^2) due to list appending at the tail, which requires traversal. This PR fixes the problem. The ordering of solver-minimize and solver-maximize matters, however (it specifies the lexicographic ordering minimization), so rearranging them is slightly more complicated.