### PR TITLE
Add support for STP and Yices2 solvers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,9 +73,9 @@ jobs:
           cmake .. &&
           cmake --build . &&
           cp stp bin/ &&
-          add-apt-repository -y ppa:sri-csl/formal-methods &&
-          apt-get update &&
-          apt-get install -y yices2 
+          sudo add-apt-repository -y ppa:sri-csl/formal-methods &&
+          sudo apt-get update &&
+          sudo apt-get install -y yices2 
 
       - name: Install Rosette
         run: raco pkg install --auto --name rosette

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install solvers
         run: |
           mkdir bin &&
-
           wget $CVC4_URL -nv -O bin/cvc4 &&
           chmod +x bin/cvc4 &&
           wget $BOOLECTOR_URL -nv -O boolector.tar.gz &&
@@ -59,7 +58,6 @@ jobs:
           popd &&
           popd &&
           cp bitwuzla/build/src/main/bitwuzla bin/ &&
-
           sudo apt-get install -y git cmake bison flex libboost-all-dev python2 perl &&
           git clone https://github.com/stp/stp &&
           pushd stp &&
@@ -76,7 +74,6 @@ jobs:
           sudo add-apt-repository -y ppa:sri-csl/formal-methods &&
           sudo apt-get update &&
           sudo apt-get install -y yices2 
-
       - name: Install Rosette
         run: raco pkg install --auto --name rosette
       - name: Compile Rosette tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install solvers
         run: |
           mkdir bin &&
+
           wget $CVC4_URL -nv -O bin/cvc4 &&
           chmod +x bin/cvc4 &&
           wget $BOOLECTOR_URL -nv -O boolector.tar.gz &&
@@ -57,7 +58,25 @@ jobs:
           ninja &&
           popd &&
           popd &&
-          cp bitwuzla/build/src/main/bitwuzla bin/ 
+          cp bitwuzla/build/src/main/bitwuzla bin/ &&
+
+          sudo apt-get install -y git cmake bison flex libboost-all-dev python2 perl &&
+          git clone https://github.com/stp/stp &&
+          pushd stp &&
+          git submodule init && git submodule update &&
+          ./scripts/deps/setup-gtest.sh &&
+          ./scripts/deps/setup-outputcheck.sh &&
+          ./scripts/deps/setup-cms.sh &&
+          ./scripts/deps/setup-minisat.sh &&
+          mkdir build &&
+          cd build &&
+          cmake .. &&
+          cmake --build . &&
+          cp stp bin/ &&
+          add-apt-repository -y ppa:sri-csl/formal-methods &&
+          apt-get update &&
+          apt-get install -y yices2 
+
       - name: Install Rosette
         run: raco pkg install --auto --name rosette
       - name: Compile Rosette tests

--- a/rosette/solver/smt/stp.rkt
+++ b/rosette/solver/smt/stp.rkt
@@ -1,0 +1,68 @@
+#lang racket
+
+(require racket/runtime-path 
+         "server.rkt" "env.rkt" 
+         "../solver.rkt"
+         (prefix-in base/ "base-solver.rkt"))
+
+(provide (rename-out [make-stp stp]) stp? stp-available?)
+
+(define-runtime-path stp-path (build-path ".." ".." ".." "bin" "stp"))
+(define stp-opts '())
+
+(define (stp-available?)
+  (not (false? (base/find-solver "stp" stp-path #f))))
+
+(define (make-stp [solver #f] #:options [options (hash)] #:logic [logic #f] #:path [path #f])
+  (define config
+    (cond
+      [(stp? solver)
+       (base/solver-config solver)]
+      [else
+       (define real-stp-path (base/find-solver "stp" stp-path path))
+       (when (and (false? real-stp-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
+         (error 'stp "stp binary is not available (expected to be at ~a); try passing the #:path argument to (stp)" (path->string (simplify-path stp-path))))
+       (base/config options real-stp-path logic)]))
+  (stp (server (base/config-path config) stp-opts (base/make-send-options config)) config '() '() '() (env) '()))
+
+(struct stp base/solver ()
+  #:property prop:solver-constructor make-stp
+  #:methods gen:custom-write
+  [(define (write-proc self port mode) (fprintf port "#<stp>"))]
+  #:methods gen:solver
+  [
+   (define (solver-features self)
+     '(qf_bv))
+
+   (define (solver-options self)
+     (base/solver-options self))
+
+   (define (solver-assert self bools)
+     (base/solver-assert self bools))
+
+   (define (solver-minimize self nums)
+     (base/solver-minimize self nums))
+
+   (define (solver-maximize self nums)
+     (base/solver-maximize self nums))
+
+   (define (solver-clear self)
+     (base/solver-clear self))
+
+   (define (solver-shutdown self)
+     (base/solver-shutdown self))
+
+   (define (solver-push self)
+     (base/solver-push self))
+
+   (define (solver-pop self [k 1])
+     (base/solver-pop self k))
+
+   (define (solver-check self)
+     (base/solver-check self))
+
+   (define (solver-debug self)
+     (base/solver-debug self))])
+
+(define (set-default-options server)
+  void)

--- a/rosette/solver/smt/stp.rkt
+++ b/rosette/solver/smt/stp.rkt
@@ -66,3 +66,4 @@
 
 (define (set-default-options server)
   void)
+  

--- a/rosette/solver/smt/yices-smt2.rkt
+++ b/rosette/solver/smt/yices-smt2.rkt
@@ -1,0 +1,68 @@
+#lang racket
+
+(require racket/runtime-path 
+         "server.rkt" "env.rkt" 
+         "../solver.rkt"
+         (prefix-in base/ "base-solver.rkt"))
+
+(provide (rename-out [make-yices-smt2 yices-smt2]) yices-smt2? yices-smt2-available?)
+
+(define-runtime-path yices-smt2-path (build-path ".." ".." ".." "bin" "yices-smt2"))
+(define yices-smt2-opts '("--incremental"))
+
+(define (yices-smt2-available?)
+  (not (false? (base/find-solver "yices-smt2" yices-smt2-path #f))))
+(define default-logic 'QF_BV) ;; YICES_2 needs a default logic set otherwise it will error
+(define (make-yices-smt2 [solver #f] #:options [options (hash)] #:logic [logic default-logic] #:path [path #f])
+  (define config
+    (cond
+      [(yices-smt2? solver)
+       (base/solver-config solver)]
+      [else
+       (define real-yices-smt2-path (base/find-solver "yices-smt2" yices-smt2-path path))
+       (when (and (false? real-yices-smt2-path) (not (getenv "PLT_PKG_BUILD_SERVICE")))
+         (error 'yices-smt2 "yices-smt2 binary is not available (expected to be at ~a); try passing the #:path argument to (yices-smt2)" (path->string (simplify-path yices-smt2-path))))
+       (base/config options real-yices-smt2-path logic)]))
+  (yices-smt2 (server (base/config-path config) yices-smt2-opts (base/make-send-options config)) config '() '() '() (env) '()))
+
+(struct yices-smt2 base/solver ()
+  #:property prop:solver-constructor make-yices-smt2
+  #:methods gen:custom-write
+  [(define (write-proc self port mode) (fprintf port "#<yices-smt2>"))]
+  #:methods gen:solver
+  [
+   (define (solver-features self)
+     '(qf_bv))
+
+   (define (solver-options self)
+     (base/solver-options self))
+
+   (define (solver-assert self bools)
+     (base/solver-assert self bools))
+
+   (define (solver-minimize self nums)
+     (base/solver-minimize self nums))
+
+   (define (solver-maximize self nums)
+     (base/solver-maximize self nums))
+
+   (define (solver-clear self)
+     (base/solver-clear self))
+
+   (define (solver-shutdown self)
+     (base/solver-shutdown self))
+
+   (define (solver-push self)
+     (base/solver-push self))
+
+   (define (solver-pop self [k 1])
+     (base/solver-pop self k))
+
+   (define (solver-check self)
+     (base/solver-check self))
+
+   (define (solver-debug self)
+     (base/solver-debug self))])
+
+(define (set-default-options server)
+  void)

--- a/rosette/solver/smt/yices-smt2.rkt
+++ b/rosette/solver/smt/yices-smt2.rkt
@@ -66,3 +66,4 @@
 
 (define (set-default-options server)
   void)
+  

--- a/test/all-rosette-tests.rkt
+++ b/test/all-rosette-tests.rkt
@@ -6,6 +6,7 @@
          rosette/solver/smt/boolector 
          rosette/solver/smt/cvc5
          rosette/solver/smt/bitwuzla
+         rosette/solver/smt/stp
          "config.rkt")
 
 (error-print-width default-error-print-width)
@@ -76,21 +77,24 @@
 
 
 (define (slow-tests)
-  (when (cvc4-available?)
-    (printf "===== Running CVC4 tests =====\n")
-    (run-tests-with-solver cvc4))
+  ; (when (cvc4-available?)
+  ;   (printf "===== Running CVC4 tests =====\n")
+  ;   (run-tests-with-solver cvc4))
 
-  (when (boolector-available?)
-    (printf "===== Running Boolector tests =====\n")
-    (run-tests-with-solver boolector))
+  ; (when (boolector-available?)
+  ;   (printf "===== Running Boolector tests =====\n")
+  ;   (run-tests-with-solver boolector))
 
-  (when (cvc5-available?)
-    (printf "===== Running cvc5 tests =====\n")
-    (run-tests-with-solver cvc5))
+  ; (when (cvc5-available?)
+  ;   (printf "===== Running cvc5 tests =====\n")
+  ;   (run-tests-with-solver cvc5))
 
-  (when (bitwuzla-available?)
-    (printf "===== Running bitwuzla tests =====\n")
-    (run-tests-with-solver bitwuzla))
+  ; (when (bitwuzla-available?)
+  ;   (printf "===== Running bitwuzla tests =====\n")
+  ;   (run-tests-with-solver bitwuzla))
+  (when (stp-available?)
+    (printf "===== Running stp tests =====\n")
+    (run-tests-with-solver stp))
 )
 
 (module+ test

--- a/test/all-rosette-tests.rkt
+++ b/test/all-rosette-tests.rkt
@@ -7,8 +7,8 @@
          rosette/solver/smt/cvc5
          rosette/solver/smt/bitwuzla
          rosette/solver/smt/stp
+         rosette/solver/smt/yices-smt2
          "config.rkt")
-
 (error-print-width default-error-print-width)
 
 
@@ -77,24 +77,27 @@
 
 
 (define (slow-tests)
-  ; (when (cvc4-available?)
-  ;   (printf "===== Running CVC4 tests =====\n")
-  ;   (run-tests-with-solver cvc4))
+  (when (cvc4-available?)
+    (printf "===== Running CVC4 tests =====\n")
+    (run-tests-with-solver cvc4))
 
-  ; (when (boolector-available?)
-  ;   (printf "===== Running Boolector tests =====\n")
-  ;   (run-tests-with-solver boolector))
+  (when (boolector-available?)
+    (printf "===== Running Boolector tests =====\n")
+    (run-tests-with-solver boolector))
 
-  ; (when (cvc5-available?)
-  ;   (printf "===== Running cvc5 tests =====\n")
-  ;   (run-tests-with-solver cvc5))
+  (when (cvc5-available?)
+    (printf "===== Running cvc5 tests =====\n")
+    (run-tests-with-solver cvc5))
 
-  ; (when (bitwuzla-available?)
-  ;   (printf "===== Running bitwuzla tests =====\n")
-  ;   (run-tests-with-solver bitwuzla))
+  (when (bitwuzla-available?)
+    (printf "===== Running bitwuzla tests =====\n")
+    (run-tests-with-solver bitwuzla))
   (when (stp-available?)
     (printf "===== Running stp tests =====\n")
     (run-tests-with-solver stp))
+  (when (yices-smt2-available?)
+    (printf "===== Running yices-smt2 tests =====\n")
+    (run-tests-with-solver yices-smt2))
 )
 
 (module+ test

--- a/test/base/bitvector.rkt
+++ b/test/base/bitvector.rkt
@@ -2,14 +2,11 @@
 
 (require rackunit rackunit/text-ui racket/generator (rename-in rackunit [check-exn rackunit/check-exn])
          rosette/solver/solution
-        ;  (only-in rosette solver-features current-solver) "solver.rkt"
-        ;  rosette/solver/smt/yices-smt2
          rosette/lib/roseunit rosette/solver/smt/boolector
          racket/fixnum 
          rosette/base/core/term
          rosette/base/core/bool
          rosette/base/core/result
-        ;  rosette/solver/smt/server
          (except-in rosette/base/core/bitvector bv)
          (only-in rosette/base/core/bitvector [bv @bv])
          rosette/base/core/polymorphic rosette/base/core/merge 
@@ -29,7 +26,6 @@
 (define maxval+1 (expt 2 (sub1 (bitvector-size BV)))) 
 (define maxval (sub1 maxval+1))
 (define (bv v [t BV]) (@bv v t))
-; (output-smt "output-debug/")
 (define-syntax-rule (check-exn e ...)
   (begin
     (rackunit/check-exn e ...)

--- a/test/base/bitvector.rkt
+++ b/test/base/bitvector.rkt
@@ -1,12 +1,15 @@
 #lang racket
 
 (require rackunit rackunit/text-ui racket/generator (rename-in rackunit [check-exn rackunit/check-exn])
-         rosette/solver/solution 
+         rosette/solver/solution
+        ;  (only-in rosette solver-features current-solver) "solver.rkt"
+        ;  rosette/solver/smt/yices-smt2
          rosette/lib/roseunit rosette/solver/smt/boolector
          racket/fixnum 
          rosette/base/core/term
          rosette/base/core/bool
          rosette/base/core/result
+        ;  rosette/solver/smt/server
          (except-in rosette/base/core/bitvector bv)
          (only-in rosette/base/core/bitvector [bv @bv])
          rosette/base/core/polymorphic rosette/base/core/merge 
@@ -26,7 +29,7 @@
 (define maxval+1 (expt 2 (sub1 (bitvector-size BV)))) 
 (define maxval (sub1 maxval+1))
 (define (bv v [t BV]) (@bv v t))
-
+; (output-smt "output-debug/")
 (define-syntax-rule (check-exn e ...)
   (begin
     (rackunit/check-exn e ...)


### PR DESCRIPTION
This PR adds support for STP and Yices2 (Yices-smt2) solvers. We initially used these solvers in our project Lakeroad, and they have performed well in our tool and in the the smtcomp2023.

I've created a PR request from, what I can tell, contains everything I need to add support for the solvers. I've 

- [ ] Added appropriate files in the `rosette/solver/smt` directory for the corresponding solvers.
- [ ] Use of the solvers in `all-rosette-tests.rkt`
- [ ] Added the solvers to the github workflows for the tests (I believe I did this properly)

Please let me know any fixes, or suggestions folks have before merging!

Thanks a bunch!
